### PR TITLE
Remove async singleton scope from documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A powerful and type-safe dependency injection/IoC (Inversion of Control) library
 - **Container validation** - Ensure all dependencies can be resolved before runtime
 - **Module system** - Organize dependencies with public/private access control
 - **Parent-child container hierarchy** - Create child containers that inherit from parent
-- **Multiple scopes** - Singleton, Transient, Request, and AsyncSingleton scopes
+- **Multiple scopes** - Singleton, Transient, and Request scopes
 - **Function injection** - Run functions with automatic dependency injection via `container.run()`
 - **Property injection** - Injectable base class for clean, declarative dependency injection
 - **Async support** - First-class support for async dependencies
@@ -165,25 +165,6 @@ def sync_handler():
     service1 = container.get(RequestService)
     service2 = container.get(RequestService)
     assert service1 is service2  # Same instance in same context
-```
-
-#### Async Singleton Scope
-
-For async dependencies:
-
-```python
-from inversipy.scopes import AsyncSingletonScope
-
-async_scope = AsyncSingletonScope()
-
-async def get_service():
-    scope = AsyncSingletonScope()
-
-    async def factory():
-        return await create_async_service()
-
-    service = await scope.get_async(factory)
-    return service
 ```
 
 ### Modules

--- a/inversipy/__init__.py
+++ b/inversipy/__init__.py
@@ -5,7 +5,7 @@ Inversipy provides a flexible dependency injection container with support for:
 - Container validation
 - Modules with public/private dependencies
 - Parent-child container hierarchy
-- Multiple scopes (Singleton, Transient, Request, AsyncSingleton)
+- Multiple scopes (Singleton, Transient, Request)
 - Function injection via container.run()
 - Property injection via Injectable base class
 - Pure classes with no container coupling


### PR DESCRIPTION
The async singleton strategy is an internal implementation detail. Async dependencies should be obtained via get_async() with regular singleton scope, not as a separate publicly documented scope.