### PR TITLE
Review collection injection implementation plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ A powerful and type-safe dependency injection/IoC (Inversion of Control) library
 - **Multiple scopes** - Singleton, Transient, and Request scopes
 - **Function injection** - Run functions with automatic dependency injection via `container.run()`
 - **Property injection** - Injectable base class for clean, declarative dependency injection
+- **Named dependencies** - Register multiple implementations with names for disambiguation
+- **Collection injection** - Register multiple implementations and inject as a collection with `InjectAll`
+- **Named collections** - Group implementations by name and inject with `InjectAllNamed`
 - **Async support** - First-class support for async dependencies
 - **Type-safe** - Full type hint support for better IDE integration
 - **Pure classes** - No container coupling - classes remain framework-agnostic
@@ -359,6 +362,126 @@ Classes using `Injectable` remain container-agnostic and can be used standalone:
 my_db = Database()
 my_logger = Logger()
 service = UserService(database=my_db, logger=my_logger)
+```
+
+### Named Dependencies
+
+Register multiple implementations of the same interface using named dependencies:
+
+```python
+from inversipy import Container, Inject, Named
+
+class IDatabase:
+    pass
+
+class PostgresDB(IDatabase):
+    pass
+
+class SQLiteDB(IDatabase):
+    pass
+
+container = Container()
+container.register(IDatabase, PostgresDB, name="primary")
+container.register(IDatabase, SQLiteDB, name="backup")
+
+# Resolve by name
+primary_db = container.get(IDatabase, name="primary")
+backup_db = container.get(IDatabase, name="backup")
+```
+
+With property injection:
+
+```python
+from inversipy import Injectable, Inject, Named
+
+class DataService(Injectable):
+    primary_db: Inject[IDatabase, Named("primary")]
+    backup_db: Inject[IDatabase, Named("backup")]
+```
+
+### Collection Injection
+
+Register multiple implementations and inject them as a collection using `InjectAll`:
+
+```python
+from inversipy import Container, InjectAll, Injectable
+
+class IPlugin:
+    def execute(self) -> str:
+        raise NotImplementedError
+
+class PluginA(IPlugin):
+    def execute(self) -> str:
+        return "PluginA executed"
+
+class PluginB(IPlugin):
+    def execute(self) -> str:
+        return "PluginB executed"
+
+# Multiple registrations accumulate (no overwriting)
+container = Container()
+container.register(IPlugin, PluginA)
+container.register(IPlugin, PluginB)
+
+# Get all implementations
+plugins = container.get_all(IPlugin)  # [PluginA(), PluginB()]
+for plugin in plugins:
+    print(plugin.execute())
+
+# Single resolution fails when ambiguous
+# container.get(IPlugin)  # raises AmbiguousDependencyError
+```
+
+With property injection:
+
+```python
+class PluginManager(Injectable):
+    plugins: InjectAll[IPlugin]
+
+    def run_all(self) -> list[str]:
+        return [plugin.execute() for plugin in self.plugins]
+
+container.register(PluginManager)
+manager = container.get(PluginManager)
+results = manager.run_all()  # ['PluginA executed', 'PluginB executed']
+```
+
+> **Migration Note**: Multiple `register()` calls for the same interface now **accumulate**
+> rather than overwrite. Code that relied on overwriting behavior should either:
+> - Use named bindings: `container.register(IPlugin, NewImpl, name="main")`
+> - Or explicitly clear bindings before re-registering
+
+### Named Collection Injection
+
+Combine named dependencies with collection injection using `InjectAll[T, Named("x")]`:
+
+```python
+from inversipy import Container, InjectAll, Named, Injectable
+
+# Register plugins in named groups
+container = Container()
+container.register(IPlugin, PluginA, name="core")
+container.register(IPlugin, PluginB, name="core")
+container.register(IPlugin, PluginC, name="optional")
+
+# Get all implementations in a named group
+core_plugins = container.get_all(IPlugin, name="core")  # [PluginA(), PluginB()]
+optional_plugins = container.get_all(IPlugin, name="optional")  # [PluginC()]
+```
+
+With property injection:
+
+```python
+class PluginManager(Injectable):
+    core_plugins: InjectAll[IPlugin, Named("core")]
+    optional_plugins: InjectAll[IPlugin, Named("optional")]
+
+    def run_core(self) -> list[str]:
+        return [p.execute() for p in self.core_plugins]
+
+container.register(PluginManager)
+manager = container.get(PluginManager)
+manager.run_core()  # Only runs core plugins
 ```
 
 ## Advanced Usage

--- a/examples/collection_injection_example.py
+++ b/examples/collection_injection_example.py
@@ -1,0 +1,256 @@
+"""Collection injection example for inversipy.
+
+This example demonstrates:
+- Registering multiple implementations of an interface
+- Collection injection with InjectAll[T]
+- Named collection injection with InjectAll[T, Named("x")]
+- Using get_all() for programmatic collection resolution
+- Plugin system pattern with grouped plugins
+"""
+
+from inversipy import (
+    Container,
+    Injectable,
+    InjectAll,
+    Named,
+)
+
+# =============================================================================
+# Plugin Interface and Implementations
+# =============================================================================
+
+
+class IPlugin:
+    """Interface for plugins."""
+
+    def get_name(self) -> str:
+        raise NotImplementedError
+
+    def execute(self) -> str:
+        raise NotImplementedError
+
+
+class LoggingPlugin(IPlugin):
+    """Plugin that logs operations."""
+
+    def get_name(self) -> str:
+        return "LoggingPlugin"
+
+    def execute(self) -> str:
+        return "Logging operation executed"
+
+
+class MetricsPlugin(IPlugin):
+    """Plugin that collects metrics."""
+
+    def get_name(self) -> str:
+        return "MetricsPlugin"
+
+    def execute(self) -> str:
+        return "Metrics collected"
+
+
+class AuthPlugin(IPlugin):
+    """Plugin that handles authentication."""
+
+    def get_name(self) -> str:
+        return "AuthPlugin"
+
+    def execute(self) -> str:
+        return "Authentication validated"
+
+
+class CachePlugin(IPlugin):
+    """Plugin that provides caching."""
+
+    def get_name(self) -> str:
+        return "CachePlugin"
+
+    def execute(self) -> str:
+        return "Cache warmed up"
+
+
+# =============================================================================
+# Plugin Manager using Collection Injection
+# =============================================================================
+
+
+class PluginManager(Injectable):
+    """Manager that uses all registered plugins via InjectAll."""
+
+    plugins: InjectAll[IPlugin]
+
+    def run_all(self) -> list[str]:
+        """Execute all plugins and return results."""
+        return [plugin.execute() for plugin in self.plugins]
+
+    def list_plugins(self) -> list[str]:
+        """Get names of all registered plugins."""
+        return [plugin.get_name() for plugin in self.plugins]
+
+
+# =============================================================================
+# Grouped Plugin Manager using Named Collection Injection
+# =============================================================================
+
+
+class GroupedPluginManager(Injectable):
+    """Manager that uses plugins grouped by category."""
+
+    core_plugins: InjectAll[IPlugin, Named("core")]
+    optional_plugins: InjectAll[IPlugin, Named("optional")]
+
+    def run_core(self) -> list[str]:
+        """Execute only core plugins."""
+        return [plugin.execute() for plugin in self.core_plugins]
+
+    def run_optional(self) -> list[str]:
+        """Execute only optional plugins."""
+        return [plugin.execute() for plugin in self.optional_plugins]
+
+    def run_all(self) -> list[str]:
+        """Execute all plugins (core + optional)."""
+        results = []
+        results.extend(self.run_core())
+        results.extend(self.run_optional())
+        return results
+
+    def get_summary(self) -> dict[str, list[str]]:
+        """Get summary of registered plugins by group."""
+        return {
+            "core": [p.get_name() for p in self.core_plugins],
+            "optional": [p.get_name() for p in self.optional_plugins],
+        }
+
+
+# =============================================================================
+# Example Functions
+# =============================================================================
+
+
+def basic_collection_example() -> None:
+    """Demonstrate basic collection injection with InjectAll."""
+    print("\n=== Basic Collection Injection ===\n")
+
+    container = Container()
+
+    # Register multiple implementations - they accumulate!
+    container.register(IPlugin, LoggingPlugin)
+    container.register(IPlugin, MetricsPlugin)
+    container.register(IPlugin, AuthPlugin)
+
+    # Direct API: get_all() returns all implementations
+    plugins = container.get_all(IPlugin)
+    print(f"Registered {len(plugins)} plugins:")
+    for plugin in plugins:
+        print(f"  - {plugin.get_name()}: {plugin.execute()}")
+
+    # Property injection: PluginManager gets all plugins
+    container.register(PluginManager)
+    manager = container.get(PluginManager)
+
+    print(f"\nPluginManager.plugins: {manager.list_plugins()}")
+    print(f"Results: {manager.run_all()}")
+
+
+def named_collection_example() -> None:
+    """Demonstrate named collection injection with InjectAll."""
+    print("\n=== Named Collection Injection ===\n")
+
+    container = Container()
+
+    # Register plugins in named groups
+    # Core plugins (required for system operation)
+    container.register(IPlugin, LoggingPlugin, name="core")
+    container.register(IPlugin, AuthPlugin, name="core")
+
+    # Optional plugins (can be disabled)
+    container.register(IPlugin, MetricsPlugin, name="optional")
+    container.register(IPlugin, CachePlugin, name="optional")
+
+    # Direct API: get_all() with name parameter
+    core = container.get_all(IPlugin, name="core")
+    optional = container.get_all(IPlugin, name="optional")
+
+    print(f"Core plugins ({len(core)}):")
+    for plugin in core:
+        print(f"  - {plugin.get_name()}")
+
+    print(f"\nOptional plugins ({len(optional)}):")
+    for plugin in optional:
+        print(f"  - {plugin.get_name()}")
+
+    # Property injection: GroupedPluginManager gets plugins by group
+    container.register(GroupedPluginManager)
+    manager = container.get(GroupedPluginManager)
+
+    print(f"\nPlugin summary: {manager.get_summary()}")
+    print(f"Core results: {manager.run_core()}")
+    print(f"Optional results: {manager.run_optional()}")
+
+
+def mixed_example() -> None:
+    """Demonstrate mixing unnamed and named collections."""
+    print("\n=== Mixed Collection Injection ===\n")
+
+    container = Container()
+
+    # Unnamed registrations (for get_all without name)
+    container.register(IPlugin, LoggingPlugin)
+    container.register(IPlugin, MetricsPlugin)
+
+    # Named registrations (for get_all with name)
+    container.register(IPlugin, AuthPlugin, name="security")
+    container.register(IPlugin, CachePlugin, name="security")
+
+    # Get unnamed plugins
+    unnamed = container.get_all(IPlugin)
+    print(f"Unnamed plugins: {[p.get_name() for p in unnamed]}")
+
+    # Get named plugins
+    security = container.get_all(IPlugin, name="security")
+    print(f"Security plugins: {[p.get_name() for p in security]}")
+
+    # Note: Named and unnamed are completely separate!
+    print(f"\nTotal unnamed: {container.count(IPlugin)}")
+    print(f"Total security: {container.count(IPlugin, name='security')}")
+
+
+def run_function_example() -> None:
+    """Demonstrate collection injection with container.run()."""
+    print("\n=== Collection Injection with container.run() ===\n")
+
+    container = Container()
+    container.register(IPlugin, LoggingPlugin)
+    container.register(IPlugin, MetricsPlugin)
+
+    # Function with InjectAll parameter
+    def process_with_plugins(plugins: InjectAll[IPlugin]) -> str:
+        names = [p.get_name() for p in plugins]
+        return f"Processed with: {', '.join(names)}"
+
+    result = container.run(process_with_plugins)
+    print(result)
+
+    # Named collection in function
+    container.register(IPlugin, AuthPlugin, name="critical")
+
+    def process_critical(plugins: InjectAll[IPlugin, Named("critical")]) -> str:
+        return f"Critical plugins: {len(plugins)}"
+
+    result = container.run(process_critical)
+    print(result)
+
+
+def main() -> None:
+    """Run all collection injection examples."""
+    basic_collection_example()
+    named_collection_example()
+    mixed_example()
+    run_function_example()
+
+    print("\n=== All examples completed! ===\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/inversipy/__init__.py
+++ b/inversipy/__init__.py
@@ -13,8 +13,16 @@ Inversipy provides a flexible dependency injection container with support for:
 """
 
 from .container import Binding, Container
-from .decorators import Inject, Injectable, extract_inject_info
+from .decorators import (
+    Inject,
+    Injectable,
+    InjectAll,
+    extract_inject_all_info,
+    extract_inject_all_type,
+    extract_inject_info,
+)
 from .exceptions import (
+    AmbiguousDependencyError,
     CircularDependencyError,
     DependencyNotFoundError,
     InvalidScopeError,
@@ -44,11 +52,15 @@ __all__ = [
     "Named",
     # Dependency injection utilities
     "Inject",
+    "InjectAll",
     "Injectable",
     "extract_inject_info",
+    "extract_inject_all_type",
+    "extract_inject_all_info",
     # Exceptions
     "InversipyError",
     "DependencyNotFoundError",
+    "AmbiguousDependencyError",
     "CircularDependencyError",
     "ValidationError",
     "InvalidScopeError",

--- a/inversipy/container.py
+++ b/inversipy/container.py
@@ -16,6 +16,7 @@ from .binding_strategies import (
 )
 from .decorators import extract_inject_info
 from .exceptions import (
+    AmbiguousDependencyError,
     CircularDependencyError,
     DependencyNotFoundError,
     RegistrationError,
@@ -340,7 +341,8 @@ class Container:
             name: Name for this container (used in error messages)
         """
         self._name = name
-        self._bindings: dict[DependencyKey, Binding] = {}
+        # Changed to list[Binding] to support multiple implementations per interface
+        self._bindings: dict[DependencyKey, list[Binding]] = {}
         self._modules: list[ModuleProtocol] = []  # List of registered modules
         self._parent = parent
         # Resolution stack now tracks DependencyKey (type or (type, name) tuple)
@@ -402,7 +404,12 @@ class Container:
             scope=scope,
             instance=instance,
         )
-        self._bindings[key] = binding
+
+        # Accumulate bindings instead of overwriting
+        if key not in self._bindings:
+            self._bindings[key] = []
+        self._bindings[key].append(binding)
+
         return self
 
     def register_factory[T](
@@ -481,6 +488,7 @@ class Container:
 
         Raises:
             DependencyNotFoundError: If dependency is not registered
+            AmbiguousDependencyError: If multiple implementations without name
             CircularDependencyError: If circular dependency is detected
 
         Example:
@@ -500,8 +508,15 @@ class Container:
             cycle_types = [get_type_from_key(k) for k in self._resolution_stack]
             raise CircularDependencyError(cycle_types)
 
-        # Try to find binding in this container
-        binding = self._bindings.get(key)
+        # Try to find bindings in this container
+        bindings = self._bindings.get(key, [])
+
+        # Check for ambiguity
+        if len(bindings) > 1:
+            raise AmbiguousDependencyError(interface, len(bindings), self._name)
+
+        # Get single binding if exists
+        binding = bindings[0] if len(bindings) == 1 else None
 
         # If not found, try registered modules
         if binding is None:
@@ -514,6 +529,9 @@ class Container:
                 except DependencyNotFoundError:
                     # This module doesn't have it (or it's private), try next module
                     continue
+                except AmbiguousDependencyError:
+                    # Propagate ambiguity errors
+                    raise
 
         # If not found, try parent container
         if binding is None and self._parent is not None:
@@ -533,12 +551,21 @@ class Container:
             # Remove from resolution stack
             self._resolution_stack.pop()
 
-    def try_get[T](self, interface: type[T], name: str | None = None) -> T | None:
+    def try_get[T](
+        self,
+        interface: type[T],
+        name: str | None = None,
+        *,
+        suppress_ambiguity: bool = False,
+    ) -> T | None:
         """Try to resolve a dependency, returning None if not found.
 
         Args:
             interface: The type to resolve
             name: Optional name qualifier for named bindings
+            suppress_ambiguity: If True, return None instead of raising
+                AmbiguousDependencyError when multiple implementations exist.
+                Default is False (raises the error).
 
         Returns:
             Resolved instance or None
@@ -547,6 +574,38 @@ class Container:
             return self.get(interface, name=name)
         except DependencyNotFoundError:
             return None
+        except AmbiguousDependencyError:
+            if suppress_ambiguity:
+                return None
+            raise
+
+    async def try_get_async[T](
+        self,
+        interface: type[T],
+        name: str | None = None,
+        *,
+        suppress_ambiguity: bool = False,
+    ) -> T | None:
+        """Try to resolve a dependency asynchronously, returning None if not found.
+
+        Args:
+            interface: The type to resolve
+            name: Optional name qualifier for named bindings
+            suppress_ambiguity: If True, return None instead of raising
+                AmbiguousDependencyError when multiple implementations exist.
+                Default is False (raises the error).
+
+        Returns:
+            Resolved instance or None
+        """
+        try:
+            return await self.get_async(interface, name=name)
+        except DependencyNotFoundError:
+            return None
+        except AmbiguousDependencyError:
+            if suppress_ambiguity:
+                return None
+            raise
 
     async def get_async[T](self, interface: type[T], name: str | None = None) -> T:
         """Resolve a dependency from the container asynchronously.
@@ -566,6 +625,7 @@ class Container:
 
         Raises:
             DependencyNotFoundError: If dependency is not registered
+            AmbiguousDependencyError: If multiple implementations without name
             CircularDependencyError: If circular dependency is detected
         """
         key = make_key(interface, name)
@@ -576,8 +636,15 @@ class Container:
             cycle_types = [get_type_from_key(k) for k in self._resolution_stack]
             raise CircularDependencyError(cycle_types)
 
-        # Try to find binding in this container
-        binding = self._bindings.get(key)
+        # Try to find bindings in this container
+        bindings = self._bindings.get(key, [])
+
+        # Check for ambiguity
+        if len(bindings) > 1:
+            raise AmbiguousDependencyError(interface, len(bindings), self._name)
+
+        # Get single binding if exists
+        binding = bindings[0] if len(bindings) == 1 else None
 
         # If not found, try registered modules
         if binding is None:
@@ -589,6 +656,9 @@ class Container:
                 except DependencyNotFoundError:
                     # This module doesn't have it (or it's private), try next module
                     continue
+                except AmbiguousDependencyError:
+                    # Propagate ambiguity errors
+                    raise
 
         # If not found, try parent container
         if binding is None and self._parent is not None:
@@ -616,11 +686,11 @@ class Container:
             name: Optional name qualifier for named bindings
 
         Returns:
-            True if registered, False otherwise
+            True if at least one implementation registered, False otherwise
         """
         key = make_key(interface, name)
 
-        if key in self._bindings:
+        if key in self._bindings and self._bindings[key]:
             return True
 
         # Check registered modules
@@ -633,6 +703,113 @@ class Container:
             return self._parent.has(interface, name=name)
 
         return False
+
+    def count(self, interface: type[Any], name: str | None = None) -> int:
+        """Count implementations registered for an interface.
+
+        Args:
+            interface: The interface type
+            name: Optional name qualifier for named bindings
+
+        Returns:
+            Number of registered implementations
+        """
+        key = make_key(interface, name)
+        total = len(self._bindings.get(key, []))
+
+        # Count from registered modules
+        for module in self._modules:
+            if hasattr(module, "count"):
+                total += module.count(interface, name=name)
+
+        # Count from parent container
+        if self._parent is not None:
+            total += self._parent.count(interface, name=name)
+
+        return total
+
+    def get_all[T](self, interface: type[T], *, name: str | None = None) -> list[T]:
+        """Resolve all implementations of an interface.
+
+        Args:
+            interface: The interface type to resolve
+            name: Optional name for named collection (default: None for unnamed bindings)
+
+        Returns:
+            List of all registered implementations (empty if none)
+
+        Example:
+            container.register(IPlugin, PluginA)
+            container.register(IPlugin, PluginB)
+            plugins = container.get_all(IPlugin)  # [PluginA(), PluginB()]
+
+            # Named collections
+            container.register(IPlugin, CorePlugin, name="core")
+            core_plugins = container.get_all(IPlugin, name="core")
+        """
+        instances: list[T] = []
+
+        # Determine the key based on whether name is provided
+        key: DependencyKey = (interface, name) if name is not None else interface
+
+        # Get from local bindings
+        bindings = self._bindings.get(key, [])
+        for binding in bindings:
+            instance = binding.create_instance(self)
+            instances.append(instance)
+
+        # Get from registered modules
+        for module in self._modules:
+            if hasattr(module, "get_all"):
+                try:
+                    module_instances = module.get_all(interface, name=name)
+                    instances.extend(module_instances)
+                except DependencyNotFoundError:
+                    pass
+
+        # Get from parent container
+        if self._parent is not None:
+            parent_instances = self._parent.get_all(interface, name=name)
+            instances.extend(parent_instances)
+
+        return instances
+
+    async def get_all_async[T](self, interface: type[T], *, name: str | None = None) -> list[T]:
+        """Resolve all implementations asynchronously.
+
+        Args:
+            interface: The interface type to resolve
+            name: Optional name for named collection (default: None for unnamed bindings)
+
+        Returns:
+            List of all registered implementations (empty if none)
+        """
+        instances: list[T] = []
+
+        # Determine the key based on whether name is provided
+        key: DependencyKey = (interface, name) if name is not None else interface
+
+        # Get from local bindings
+        bindings = self._bindings.get(key, [])
+        for binding in bindings:
+            instance = await binding.create_instance_async(self)
+            instances.append(instance)
+
+        # Get from registered modules
+        for module in self._modules:
+            if hasattr(module, "get_all_async"):
+                try:
+                    module_instances = await module.get_all_async(interface, name=name)
+                    instances.extend(module_instances)
+                except DependencyNotFoundError:
+                    pass
+
+        # Get from parent container
+        if self._parent is not None:
+            parent_instances = await self._parent.get_all_async(interface, name=name)
+            instances.extend(parent_instances)
+
+        return instances
 
     def run[T](self, func: Callable[..., T], **provided_kwargs: Any) -> T:
         """Run a function with dependency injection using synchronous resolution.
@@ -697,6 +874,13 @@ class Container:
                 param_type = type_hints.get(param_name)
 
                 if param_type is not None:
+                    # Check for InjectAll/InjectAllNamed annotation first
+                    inject_all_info = self._extract_inject_all_info(param_type)
+                    if inject_all_info is not None:
+                        item_type, coll_name = inject_all_info
+                        resolved_kwargs[param_name] = self.get_all(item_type, name=coll_name)
+                        continue
+
                     # Check for Inject[T, Named(...)] annotations
                     inject_info = extract_inject_info(param_type)
                     if inject_info:
@@ -729,7 +913,13 @@ class Container:
             return func(**resolved_kwargs)
 
         except Exception as e:
-            if isinstance(e, (ResolutionError, DependencyNotFoundError, CircularDependencyError)):
+            resolution_errors = (
+                ResolutionError,
+                DependencyNotFoundError,
+                CircularDependencyError,
+                AmbiguousDependencyError,
+            )
+            if isinstance(e, resolution_errors):
                 raise
             raise ResolutionError(f"Failed to run function '{func.__name__}': {e}")
 
@@ -797,6 +987,16 @@ class Container:
                 param_type = type_hints.get(param_name)
 
                 if param_type is not None:
+                    # Check for InjectAll/InjectAllNamed annotation first
+                    inject_all_info = self._extract_inject_all_info(param_type)
+                    if inject_all_info is not None:
+                        item_type, coll_name = inject_all_info
+                        all_instances: list[Any] = await self.get_all_async(
+                            item_type, name=coll_name
+                        )
+                        resolved_kwargs[param_name] = all_instances
+                        continue
+
                     # Check for Inject[T, Named(...)] annotations
                     inject_info = extract_inject_info(param_type)
                     if inject_info:
@@ -831,7 +1031,13 @@ class Container:
             return func(**resolved_kwargs)
 
         except Exception as e:
-            if isinstance(e, (ResolutionError, DependencyNotFoundError, CircularDependencyError)):
+            resolution_errors = (
+                ResolutionError,
+                DependencyNotFoundError,
+                CircularDependencyError,
+                AmbiguousDependencyError,
+            )
+            if isinstance(e, resolution_errors):
                 raise
             raise ResolutionError(f"Failed to run function '{func.__name__}': {e}")
 
@@ -839,7 +1045,8 @@ class Container:
         """Create an instance of a class, resolving its dependencies.
 
         Supports both regular constructor injection and Injectable classes with
-        named dependencies via Inject[Type, Named("qualifier")].
+        named dependencies via Inject[Type, Named("qualifier")] and collection
+        injection via InjectAll[Type].
 
         Args:
             cls: The class to instantiate
@@ -851,23 +1058,35 @@ class Container:
             ResolutionError: If instance creation fails
         """
         try:
-            # Check if this is an Injectable class with named dependency metadata
+            # Check if this is an Injectable class with dependency metadata
             inject_fields: dict[str, tuple[type, str | None]] | None = getattr(
                 cls, "_inject_fields", None
             )
+            inject_all_fields: dict[str, tuple[type, str | None]] | None = getattr(
+                cls, "_inject_all_fields", None
+            )
 
-            if inject_fields:
+            if inject_fields or inject_all_fields:
                 # Injectable class - use the stored field metadata
                 kwargs: dict[str, Any] = {}
-                for field_name, (field_type, dep_name) in inject_fields.items():
-                    try:
-                        kwargs[field_name] = self.get(field_type, name=dep_name)
-                    except DependencyNotFoundError:
-                        raise ResolutionError(
-                            f"Cannot resolve dependency '{field_name}' of type "
-                            f"{_format_dependency(field_type, dep_name)} "
-                            f"for class '{cls.__name__}'"
-                        )
+
+                # Handle single dependencies
+                if inject_fields:
+                    for field_name, (field_type, dep_name) in inject_fields.items():
+                        try:
+                            kwargs[field_name] = self.get(field_type, name=dep_name)
+                        except DependencyNotFoundError:
+                            raise ResolutionError(
+                                f"Cannot resolve dependency '{field_name}' of type "
+                                f"{_format_dependency(field_type, dep_name)} "
+                                f"for class '{cls.__name__}'"
+                            )
+
+                # Handle collection dependencies
+                if inject_all_fields:
+                    for field_name, (item_type, coll_name) in inject_all_fields.items():
+                        kwargs[field_name] = self.get_all(item_type, name=coll_name)
+
                 return cls(**kwargs)
 
             # Regular class - use constructor inspection
@@ -900,6 +1119,13 @@ class Container:
                 param_type = type_hints.get(param_name)
 
                 if param_type is not None:
+                    # Check for InjectAll/InjectAllNamed annotation first
+                    inject_all_info = self._extract_inject_all_info(param_type)
+                    if inject_all_info is not None:
+                        item_type, coll_name = inject_all_info
+                        kwargs[param_name] = self.get_all(item_type, name=coll_name)
+                        continue
+
                     # Check for Inject annotation with optional Named qualifier
                     inject_info = extract_inject_info(param_type)
                     if inject_info:
@@ -942,7 +1168,8 @@ class Container:
         """Create an instance of a class asynchronously, resolving its dependencies.
 
         Supports both regular constructor injection and Injectable classes with
-        named dependencies via Inject[Type, Named("qualifier")].
+        named dependencies via Inject[Type, Named("qualifier")] and collection
+        injection via InjectAll[Type].
 
         Args:
             cls: The class to instantiate
@@ -954,23 +1181,35 @@ class Container:
             ResolutionError: If instance creation fails
         """
         try:
-            # Check if this is an Injectable class with named dependency metadata
+            # Check if this is an Injectable class with dependency metadata
             inject_fields: dict[str, tuple[type, str | None]] | None = getattr(
                 cls, "_inject_fields", None
             )
+            inject_all_fields: dict[str, tuple[type, str | None]] | None = getattr(
+                cls, "_inject_all_fields", None
+            )
 
-            if inject_fields:
+            if inject_fields or inject_all_fields:
                 # Injectable class - use the stored field metadata
                 kwargs: dict[str, Any] = {}
-                for field_name, (field_type, dep_name) in inject_fields.items():
-                    try:
-                        kwargs[field_name] = await self.get_async(field_type, name=dep_name)
-                    except DependencyNotFoundError:
-                        raise ResolutionError(
-                            f"Cannot resolve dependency '{field_name}' of type "
-                            f"{_format_dependency(field_type, dep_name)} "
-                            f"for class '{cls.__name__}'"
-                        )
+
+                # Handle single dependencies
+                if inject_fields:
+                    for field_name, (field_type, dep_name) in inject_fields.items():
+                        try:
+                            kwargs[field_name] = await self.get_async(field_type, name=dep_name)
+                        except DependencyNotFoundError:
+                            raise ResolutionError(
+                                f"Cannot resolve dependency '{field_name}' of type "
+                                f"{_format_dependency(field_type, dep_name)} "
+                                f"for class '{cls.__name__}'"
+                            )
+
+                # Handle collection dependencies
+                if inject_all_fields:
+                    for field_name, (item_type, coll_name) in inject_all_fields.items():
+                        kwargs[field_name] = await self.get_all_async(item_type, name=coll_name)
+
                 return cls(**kwargs)
 
             # Regular class - use constructor inspection
@@ -1003,6 +1242,13 @@ class Container:
                 param_type = type_hints.get(param_name)
 
                 if param_type is not None:
+                    # Check for InjectAll/InjectAllNamed annotation first
+                    inject_all_info = self._extract_inject_all_info(param_type)
+                    if inject_all_info is not None:
+                        item_type, coll_name = inject_all_info
+                        kwargs[param_name] = await self.get_all_async(item_type, name=coll_name)
+                        continue
+
                     # Check for Inject annotation with optional Named qualifier
                     inject_info = extract_inject_info(param_type)
                     if inject_info:
@@ -1104,41 +1350,45 @@ class Container:
         # Build dependency graph for implementations only
         graph: dict[type[Any], list[type[Any]]] = {}
 
-        for key, binding in self._bindings.items():
-            if binding.instance is not None or binding.factory is not None:
-                continue
-            if binding.implementation is not None:
-                # Extract the type from the key (handles both type and (type, name) tuples)
-                node_type = get_type_from_key(key)
-                deps = self._get_implementation_dependencies(binding.implementation)
-                # Only include dependencies that are registered in this container
-                registered_deps = [
-                    d
-                    for d in deps
-                    if d in self._bindings
-                    or any(d in m._bindings for m in self._modules if hasattr(m, "_bindings"))
-                ]
-                graph[node_type] = registered_deps
+        for key, bindings in self._bindings.items():
+            for binding in bindings:
+                if binding.instance is not None or binding.factory is not None:
+                    continue
+                if binding.implementation is not None:
+                    # Extract the type from the key (handles both type and (type, name) tuples)
+                    node_type = get_type_from_key(key)
+                    deps = self._get_implementation_dependencies(binding.implementation)
+                    # Only include dependencies that are registered in this container
+                    registered_deps = [
+                        d
+                        for d in deps
+                        if d in self._bindings
+                        or any(d in m._bindings for m in self._modules if hasattr(m, "_bindings"))
+                    ]
+                    graph[node_type] = registered_deps
 
         # Also check modules
         for module in self._modules:
             if hasattr(module, "_bindings"):
-                for key, binding in module._bindings.items():
-                    if binding.instance is not None or binding.factory is not None:
-                        continue
-                    if binding.implementation is not None:
-                        node_type = get_type_from_key(key)
-                        deps = self._get_implementation_dependencies(binding.implementation)
-                        registered_deps = [
-                            d
-                            for d in deps
-                            if d in self._bindings
-                            or d in module._bindings
-                            or any(
-                                d in m._bindings for m in self._modules if hasattr(m, "_bindings")
-                            )
-                        ]
-                        graph[node_type] = registered_deps
+                for key, bindings in module._bindings.items():
+                    for binding in bindings:
+                        if binding.instance is not None or binding.factory is not None:
+                            continue
+                        if binding.implementation is not None:
+                            node_type = get_type_from_key(key)
+                            deps = self._get_implementation_dependencies(binding.implementation)
+                            registered_deps = [
+                                d
+                                for d in deps
+                                if d in self._bindings
+                                or d in module._bindings
+                                or any(
+                                    d in m._bindings
+                                    for m in self._modules
+                                    if hasattr(m, "_bindings")
+                                )
+                            ]
+                            graph[node_type] = registered_deps
 
         # DFS to detect cycles
         cycles: list[list[type[Any]]] = []
@@ -1175,6 +1425,7 @@ class Container:
         This checks:
         - All required dependencies are registered
         - No circular dependencies exist
+        - No ambiguous dependencies (multiple implementations without name qualifier)
 
         Raises:
             ValidationError: If validation fails
@@ -1187,92 +1438,155 @@ class Container:
             chain_str = " -> ".join(t.__name__ for t in cycle)
             errors.append(f"Circular dependency detected: {chain_str}")
 
-        for key, binding in self._bindings.items():
-            # Skip validation for instances and factories
-            if binding.instance is not None or binding.factory is not None:
-                continue
+        for key, bindings in self._bindings.items():
+            for binding in bindings:
+                # Skip validation for instances and factories
+                if binding.instance is not None or binding.factory is not None:
+                    continue
 
-            # Validate implementation can be instantiated
-            if binding.implementation is not None:
-                cls = binding.implementation
-                try:
-                    # Get type hints for the constructor (with extras for Annotated)
-                    init_method = cls.__init__
+                # Validate implementation can be instantiated
+                if binding.implementation is not None:
+                    cls = binding.implementation
                     try:
-                        type_hints = get_type_hints(init_method, include_extras=True)
-                    except Exception:
-                        continue  # Skip if we can't get type hints
+                        # Get type hints for the constructor (with extras for Annotated)
+                        init_method = cls.__init__
+                        try:
+                            type_hints = get_type_hints(init_method, include_extras=True)
+                        except Exception:
+                            continue  # Skip if we can't get type hints
 
-                    type_hints.pop("return", None)
+                        type_hints.pop("return", None)
 
-                    # Get constructor signature
-                    sig = inspect.signature(init_method)
+                        # Get constructor signature
+                        sig = inspect.signature(init_method)
 
-                    # Check each parameter
-                    for param_name, param in sig.parameters.items():
-                        if param_name == "self":
-                            continue
+                        # Check each parameter
+                        for param_name, param in sig.parameters.items():
+                            if param_name == "self":
+                                continue
 
-                        # Skip *args and **kwargs
-                        if param.kind in (
-                            inspect.Parameter.VAR_POSITIONAL,
-                            inspect.Parameter.VAR_KEYWORD,
-                        ):
-                            continue
+                            # Skip *args and **kwargs
+                            if param.kind in (
+                                inspect.Parameter.VAR_POSITIONAL,
+                                inspect.Parameter.VAR_KEYWORD,
+                            ):
+                                continue
 
-                        param_type = type_hints.get(param_name)
+                            param_type = type_hints.get(param_name)
 
-                        if param_type is not None:
-                            # Check for Inject[T, Named(...)] annotations
-                            inject_info = extract_inject_info(param_type)
-                            if inject_info:
-                                actual_type, dep_name = inject_info
-                                dep_key = make_key(actual_type, dep_name)
-                                # Check bindings directly (not has()) to include private deps
-                                has_dependency = (
-                                    dep_key in self._bindings
-                                    or any(
-                                        dep_key in m._bindings
-                                        for m in self._modules
-                                        if hasattr(m, "_bindings")
-                                    )
-                                    or (
-                                        self._parent is not None
-                                        and self._parent.has(actual_type, name=dep_name)
-                                    )
-                                )
-                                if not has_dependency:
-                                    if param.default is inspect.Parameter.empty:
-                                        errors.append(
-                                            f"Dependency '{cls.__name__}' requires "
-                                            f"'{_format_dependency(actual_type, dep_name)}' "
-                                            f"(parameter '{param_name}') which is not registered"
+                            if param_type is not None:
+                                # Check for InjectAll/InjectAllNamed - always valid (even if empty)
+                                inject_all_info = self._extract_inject_all_info(param_type)
+                                if inject_all_info is not None:
+                                    continue
+
+                                # Check if this param is in Injectable's _inject_all_fields
+                                # (Injectable transforms InjectAll[T] to list[T] in __init__)
+                                inject_all_fields = getattr(cls, "_inject_all_fields", None)
+                                if inject_all_fields and param_name in inject_all_fields:
+                                    continue
+
+                                # Check for Inject[T, Named(...)] annotations
+                                inject_info = extract_inject_info(param_type)
+                                if inject_info:
+                                    actual_type, dep_name = inject_info
+                                    dep_key = make_key(actual_type, dep_name)
+                                    # Check bindings directly (not has()) to include private deps
+                                    has_dependency = (
+                                        dep_key in self._bindings
+                                        and self._bindings[dep_key]
+                                        or any(
+                                            dep_key in m._bindings and m._bindings[dep_key]
+                                            for m in self._modules
+                                            if hasattr(m, "_bindings")
                                         )
-                            else:
-                                # Regular type hint - check if registered
-                                has_dependency = (
-                                    param_type in self._bindings
-                                    or any(
-                                        param_type in m._bindings
-                                        for m in self._modules
-                                        if hasattr(m, "_bindings")
-                                    )
-                                    or (self._parent is not None and self._parent.has(param_type))
-                                )
-                                if not has_dependency:
-                                    if param.default is inspect.Parameter.empty:
-                                        type_name = getattr(param_type, "__name__", str(param_type))
-                                        errors.append(
-                                            f"Dependency '{cls.__name__}' requires "
-                                            f"'{type_name}' (parameter '{param_name}') "
-                                            f"which is not registered"
+                                        or (
+                                            self._parent is not None
+                                            and self._parent.has(actual_type, name=dep_name)
                                         )
+                                    )
+                                    if not has_dependency:
+                                        if param.default is inspect.Parameter.empty:
+                                            dep_fmt = _format_dependency(actual_type, dep_name)
+                                            errors.append(
+                                                f"Dependency '{cls.__name__}' requires "
+                                                f"'{dep_fmt}' (parameter '{param_name}') "
+                                                f"which is not registered"
+                                            )
+                                else:
+                                    # Regular type hint - check if registered
+                                    has_in_parent = self._parent is not None and self._parent.has(
+                                        param_type
+                                    )
+                                    has_dependency = (
+                                        param_type in self._bindings
+                                        and self._bindings[param_type]
+                                        or any(
+                                            param_type in m._bindings and m._bindings[param_type]
+                                            for m in self._modules
+                                            if hasattr(m, "_bindings")
+                                        )
+                                        or has_in_parent
+                                    )
+                                    if not has_dependency:
+                                        if param.default is inspect.Parameter.empty:
+                                            type_name = getattr(
+                                                param_type, "__name__", str(param_type)
+                                            )
+                                            errors.append(
+                                                f"Dependency '{cls.__name__}' requires "
+                                                f"'{type_name}' (parameter '{param_name}') "
+                                                f"which is not registered"
+                                            )
+                                    elif param.default is inspect.Parameter.empty:
+                                        # Check for ambiguous dependency
+                                        dep_count = self.count(param_type)
+                                        if dep_count > 1:
+                                            type_name = getattr(
+                                                param_type, "__name__", str(param_type)
+                                            )
+                                            errors.append(
+                                                f"Dependency '{cls.__name__}' requires "
+                                                f"'{type_name}' (parameter '{param_name}') "
+                                                f"but {dep_count} implementations are "
+                                                f"registered. Use Inject[{type_name}, "
+                                                f"Named('...')] to disambiguate or "
+                                                f"InjectAll[{type_name}] for collection."
+                                            )
 
-                except Exception as e:
-                    errors.append(f"Failed to validate dependency '{cls.__name__}': {e}")
+                    except Exception as e:
+                        errors.append(f"Failed to validate dependency '{cls.__name__}': {e}")
 
         if errors:
             raise ValidationError(errors)
+
+    def _extract_inject_all_type(self, type_hint: Any) -> type | None:
+        """Extract item type from InjectAll[T] -> T.
+
+        Args:
+            type_hint: The type annotation to check
+
+        Returns:
+            The item type T if this is InjectAll[T], None otherwise
+        """
+        result = self._extract_inject_all_info(type_hint)
+        if result is not None:
+            return result[0]
+        return None
+
+    def _extract_inject_all_info(self, type_hint: Any) -> tuple[type, str | None] | None:
+        """Extract item type and optional name from InjectAll or InjectAllNamed annotation.
+
+        Args:
+            type_hint: The type annotation to check
+
+        Returns:
+            Tuple of (item_type, name | None) if this is InjectAll/InjectAllNamed, None otherwise
+        """
+        # Import here to avoid circular imports
+        from .decorators import extract_inject_all_info
+
+        return extract_inject_all_info(type_hint)
 
     def __repr__(self) -> str:
         """Get string representation of the container."""

--- a/inversipy/decorators.py
+++ b/inversipy/decorators.py
@@ -16,14 +16,24 @@ class _InjectMarker:
     pass
 
 
-# Singleton marker instance
+class _InjectAllMarker:
+    """Internal marker class for collection injection."""
+
+    pass
+
+
+# Singleton marker instances
 _inject_marker = _InjectMarker()
+_inject_all_marker = _InjectAllMarker()
 
 
 type Inject[T, *Ts] = Annotated[T, _inject_marker, *Ts]
 
+type InjectAll[T, *Ts] = Annotated[list[T], _inject_all_marker, *Ts]
+
 # Store reference to the Inject TypeAliasType for runtime checks
 _InjectAliasType = Inject  # type: ignore[type-arg]
+_InjectAllAliasType = InjectAll  # type: ignore[type-arg]
 """Type alias for dependency injection with optional qualifiers.
 
 Use Inject[T] to mark class attributes or function parameters for injection.
@@ -90,13 +100,16 @@ class Injectable:
     def __init_subclass__(cls, **kwargs: Any) -> None:
         """Called when a class inherits from Injectable.
 
-        Scans for Inject[Type] and Inject[Type, Named("x")] attributes and generates __init__.
+        Scans for Inject[Type], Inject[Type, Named("x")], InjectAll[Type],
+        and InjectAllNamed[Type, Named("x")] attributes and generates __init__.
         """
         super().__init_subclass__(**kwargs)
 
-        # Scan class annotations for Inject markers
-        # Now stores (type, name | None) tuples to support named dependencies
+        # Scan class annotations for Inject and InjectAll markers
+        # inject_fields stores (type, name | None) tuples for single dependencies
         inject_fields: dict[str, tuple[type[Any], str | None]] = {}
+        # inject_all_fields stores (item_type, name | None) tuples for collection dependencies
+        inject_all_fields: dict[str, tuple[type[Any], str | None]] = {}
 
         # Get type hints from the class to resolve type aliases
         # Use include_extras=True to preserve Annotated metadata
@@ -109,6 +122,21 @@ class Injectable:
         for attr_name, annotation in annotations.items():
             origin = get_origin(annotation)
 
+            # Check if this uses the InjectAll TypeAliasType (Python 3.12+)
+            # Handles both InjectAll[T] and InjectAll[T, Named("x")]
+            if origin is _InjectAllAliasType:
+                args = get_args(annotation)
+                if args:
+                    # First arg is the item type
+                    item_type = args[0]
+                    # Remaining args are qualifiers (e.g., Named)
+                    named_qualifier: str | None = None
+                    for arg in args[1:]:
+                        if isinstance(arg, Named):
+                            named_qualifier = arg.name
+                    inject_all_fields[attr_name] = (item_type, named_qualifier)
+                continue
+
             # Check if this uses the Inject TypeAliasType (Python 3.12+)
             # When origin is the Inject TypeAliasType, it's implicitly an inject annotation
             if origin is _InjectAliasType:
@@ -117,18 +145,38 @@ class Injectable:
                     # First arg is the actual type
                     actual_type = args[0]
                     # Remaining args are qualifiers (e.g., Named)
-                    named_qualifier: str | None = None
+                    named_qualifier = None
                     for arg in args[1:]:
                         if isinstance(arg, Named):
                             named_qualifier = arg.name
                     inject_fields[attr_name] = (actual_type, named_qualifier)
-            # Also support raw Annotated[Type, _InjectMarker, ...] for compatibility
-            elif origin is Annotated:
+                continue
+
+            # Also support raw Annotated[...] for compatibility
+            if origin is Annotated:
                 args = get_args(annotation)
                 if len(args) >= 2:
                     # First arg is the actual type, rest are metadata
                     actual_type = args[0]
                     metadata = args[1:]
+
+                    # Check for InjectAll marker first
+                    has_inject_all = False
+                    named_qualifier = None
+                    for meta in metadata:
+                        if isinstance(meta, _InjectAllMarker):
+                            has_inject_all = True
+                        elif isinstance(meta, Named):
+                            named_qualifier = meta.name
+
+                    if has_inject_all:
+                        # Extract T from list[T]
+                        list_origin = get_origin(actual_type)
+                        if list_origin is list:
+                            list_args = get_args(actual_type)
+                            if list_args:
+                                inject_all_fields[attr_name] = (list_args[0], named_qualifier)
+                        continue
 
                     # Check for Inject marker and Named qualifier
                     has_inject = False
@@ -145,16 +193,19 @@ class Injectable:
 
         # Store inject fields metadata on the class
         setattr(cls, "_inject_fields", inject_fields)
+        setattr(cls, "_inject_all_fields", inject_all_fields)
 
         # Generate __init__ method
-        if inject_fields:
+        if inject_fields or inject_all_fields:
             # Check if class already has custom __init__
             has_custom_init = "__init__" in cls.__dict__
             original_init = cls.__init__ if has_custom_init else None
 
             # Create function that accepts dependency parameters
-            param_names = list(inject_fields.keys())
-            param_types = [t for t, _ in inject_fields.values()]
+            # Combine both inject_fields and inject_all_fields
+            param_names = list(inject_fields.keys()) + list(inject_all_fields.keys())
+            param_types: list[type[Any]] = [t for t, _ in inject_fields.values()]
+            param_types.extend([list] * len(inject_all_fields))
 
             # Build the function code
             def make_init(field_names: list[str]) -> Callable[..., None]:
@@ -174,9 +225,13 @@ class Injectable:
             new_init = make_init(param_names)
 
             # Set proper annotations on the function
+            field_types = [t for t, _ in inject_fields.values()]
             init_annotations: dict[str, Any] = {
-                name: typ for name, typ in zip(param_names, param_types)
+                name: typ for name, typ in zip(list(inject_fields.keys()), field_types)
             }
+            # Add inject_all fields with list[T] annotation
+            for name, (item_type, _) in inject_all_fields.items():
+                init_annotations[name] = list[item_type]  # type: ignore
             init_annotations["return"] = None
             new_init.__annotations__ = init_annotations
 
@@ -248,5 +303,98 @@ def extract_inject_info(type_hint: Any) -> tuple[type[Any], str | None] | None:
 
         if has_inject:
             return (actual_type, name)
+
+    return None
+
+
+def extract_inject_all_type(type_hint: Any) -> type[Any] | None:
+    """Extract item type from InjectAll[T] -> T.
+
+    This helper function analyzes a type hint to determine if it's an InjectAll
+    annotation and extracts the collection item type.
+
+    Args:
+        type_hint: The type annotation to analyze
+
+    Returns:
+        The item type T if this is InjectAll[T], None otherwise.
+
+    Examples:
+        >>> extract_inject_all_type(InjectAll[IPlugin])
+        IPlugin
+
+        >>> extract_inject_all_type(list[IPlugin])
+        None
+
+        >>> extract_inject_all_type(Inject[IPlugin])
+        None
+    """
+    result = extract_inject_all_info(type_hint)
+    if result is not None:
+        return result[0]
+    return None
+
+
+def extract_inject_all_info(type_hint: Any) -> tuple[type[Any], str | None] | None:
+    """Extract item type and optional name from InjectAll annotation.
+
+    This helper function analyzes a type hint to determine if it's an InjectAll
+    annotation and extracts the collection item type and optional name.
+
+    Args:
+        type_hint: The type annotation to analyze
+
+    Returns:
+        A tuple of (item_type, name | None) if this is InjectAll, None otherwise.
+
+    Examples:
+        >>> extract_inject_all_info(InjectAll[IPlugin])
+        (IPlugin, None)
+
+        >>> extract_inject_all_info(InjectAll[IPlugin, Named("core")])
+        (IPlugin, "core")
+
+        >>> extract_inject_all_info(list[IPlugin])
+        None
+    """
+    origin = get_origin(type_hint)
+
+    # Check if this uses the InjectAll TypeAliasType (Python 3.12+)
+    # Handles both InjectAll[T] and InjectAll[T, Named("x")]
+    if origin is _InjectAllAliasType:
+        args = get_args(type_hint)
+        if args:
+            item_type = args[0]
+            name: str | None = None
+            for arg in args[1:]:
+                if isinstance(arg, Named):
+                    name = arg.name
+            return (item_type, name)
+        return None
+
+    # Also support raw Annotated[list[T], _InjectAllMarker, ...] for compatibility
+    if origin is Annotated:
+        args = get_args(type_hint)
+        if len(args) < 2:
+            return None
+
+        actual_type = args[0]  # list[T]
+        metadata = args[1:]
+
+        has_inject_all = False
+        name = None
+        for meta in metadata:
+            if isinstance(meta, _InjectAllMarker):
+                has_inject_all = True
+            elif isinstance(meta, Named):
+                name = meta.name
+
+        if has_inject_all:
+            # Extract T from list[T]
+            list_origin = get_origin(actual_type)
+            if list_origin is list:
+                list_args = get_args(actual_type)
+                if list_args:
+                    return (list_args[0], name)
 
     return None

--- a/inversipy/exceptions.py
+++ b/inversipy/exceptions.py
@@ -68,3 +68,28 @@ class ResolutionError(InversipyError):
     """Raised when there's an error during dependency resolution."""
 
     pass
+
+
+class AmbiguousDependencyError(InversipyError):
+    """Raised when multiple implementations exist for a single get() call.
+
+    This error indicates that the container has multiple implementations
+    registered for the requested interface, and it cannot determine which
+    one to return. Use get_all() to retrieve all implementations, or use
+    named bindings to disambiguate.
+    """
+
+    def __init__(
+        self,
+        dependency_type: type[Any],
+        count: int,
+        container_name: str = "container",
+    ) -> None:
+        self.dependency_type = dependency_type
+        self.count = count
+        self.container_name = container_name
+        super().__init__(
+            f"Ambiguous dependency: {count} implementations of "
+            f"'{dependency_type.__name__}' registered in {container_name}. "
+            f"Use get_all() for collection injection or register with name= for disambiguation."
+        )

--- a/inversipy/fastapi.py
+++ b/inversipy/fastapi.py
@@ -5,7 +5,7 @@ from collections.abc import Callable
 from typing import Any, get_type_hints
 
 from .container import Container
-from .decorators import extract_inject_info
+from .decorators import extract_inject_all_info, extract_inject_info
 
 try:
     from fastapi import Depends, Request  # type: ignore[import-not-found]
@@ -52,7 +52,8 @@ def inject[T](func: Callable[..., T]) -> Callable[..., T]:
     """Decorator for FastAPI routes that auto-injects dependencies.
 
     Transforms route handlers by:
-    1. Identifying parameters marked with Inject[Type] or Inject[Type, Named("x")]
+    1. Identifying parameters marked with Inject[Type], Inject[Type, Named("x")],
+       InjectAll[Type], or InjectAll[Type, Named("x")]
     2. Resolving them from the container
     3. Passing them to the original function
 
@@ -66,9 +67,13 @@ def inject[T](func: Callable[..., T]) -> Callable[..., T]:
             db: Inject[Database],
             logger: Inject[Logger],
             primary_db: Inject[IDatabase, Named("primary")],
+            plugins: InjectAll[IPlugin],
+            core_plugins: InjectAll[IPlugin, Named("core")],
             limit: int = 10
         ):
             logger.info(f"Fetching {limit} users")
+            for plugin in plugins:
+                plugin.process()
             return db.query("SELECT * FROM users LIMIT ?", limit)
         ```
 
@@ -81,7 +86,9 @@ def inject[T](func: Callable[..., T]) -> Callable[..., T]:
             db = container.get(Database)
             logger = container.get(Logger)
             primary_db = container.get(IDatabase, name="primary")
-            return original_get_users(db, logger, primary_db, limit)
+            plugins = container.get_all(IPlugin)
+            core_plugins = container.get_all(IPlugin, name="core")
+            return original_get_users(db, logger, primary_db, plugins, core_plugins, limit)
         ```
     """
     # Get function signature and type hints
@@ -90,16 +97,22 @@ def inject[T](func: Callable[..., T]) -> Callable[..., T]:
 
     # Identify which parameters need injection vs normal parameters
     inject_params: dict[str, tuple[type, str | None]] = {}
+    inject_all_params: dict[str, tuple[type, str | None]] = {}
     normal_params: list[tuple[str, inspect.Parameter]] = []
 
     for param_name, param in sig.parameters.items():
         if param_name in type_hints:
             hint = type_hints[param_name]
-            inject_info = extract_inject_info(hint)
-            if inject_info is not None:
-                inject_params[param_name] = inject_info
+            # Check for InjectAll/InjectAllNamed first
+            inject_all_info = extract_inject_all_info(hint)
+            if inject_all_info is not None:
+                inject_all_params[param_name] = inject_all_info
             else:
-                normal_params.append((param_name, param))
+                inject_info = extract_inject_info(hint)
+                if inject_info is not None:
+                    inject_params[param_name] = inject_info
+                else:
+                    normal_params.append((param_name, param))
         else:
             normal_params.append((param_name, param))
 
@@ -112,6 +125,8 @@ def inject[T](func: Callable[..., T]) -> Callable[..., T]:
             injected: dict[str, Any] = {}
             for param_name, (param_type, dep_name) in inject_params.items():
                 injected[param_name] = container.get(param_type, name=dep_name)
+            for param_name, (item_type, coll_name) in inject_all_params.items():
+                injected[param_name] = container.get_all(item_type, name=coll_name)
 
             # Merge with normal parameters passed by FastAPI
             all_params = {**kwargs, **injected}
@@ -127,6 +142,8 @@ def inject[T](func: Callable[..., T]) -> Callable[..., T]:
             injected: dict[str, Any] = {}
             for param_name, (param_type, dep_name) in inject_params.items():
                 injected[param_name] = container.get(param_type, name=dep_name)
+            for param_name, (item_type, coll_name) in inject_all_params.items():
+                injected[param_name] = container.get_all(item_type, name=coll_name)
 
             # Merge with normal parameters passed by FastAPI
             all_params = {**kwargs, **injected}

--- a/inversipy/module.py
+++ b/inversipy/module.py
@@ -267,6 +267,78 @@ class Module(Container):
         """
         return self.is_public(interface, name=name)
 
+    def count(self, interface: type[Any], name: str | None = None) -> int:
+        """Count public implementations registered for an interface.
+
+        Args:
+            interface: The interface type
+            name: Optional name qualifier for named bindings
+
+        Returns:
+            Number of public registered implementations
+        """
+        key = make_key(interface, name)
+        # Only count if this key is public
+        if key not in self._public_keys:
+            return 0
+        return len(self._bindings.get(key, []))
+
+    def get_all[T](self, interface: type[T], *, name: str | None = None) -> list[T]:
+        """Resolve all public implementations of an interface.
+
+        Args:
+            interface: The interface type to resolve
+            name: Optional name for named collection (default: None for unnamed bindings)
+
+        Returns:
+            List of all public registered implementations (empty if none)
+        """
+        key: DependencyKey = make_key(interface, name)
+
+        # If we're in the middle of resolving something, allow internal access
+        if self._resolution_stack:
+            return super().get_all(interface, name=name)
+
+        # External call - only return if the interface key is public
+        if key not in self._public_keys:
+            return []
+
+        # Only resolve from local bindings (don't include child modules)
+        instances: list[T] = []
+        bindings = self._bindings.get(key, [])
+        for binding in bindings:
+            instance = binding.create_instance(self)
+            instances.append(instance)
+        return instances
+
+    async def get_all_async[T](self, interface: type[T], *, name: str | None = None) -> list[T]:
+        """Resolve all public implementations asynchronously.
+
+        Args:
+            interface: The interface type to resolve
+            name: Optional name for named collection (default: None for unnamed bindings)
+
+        Returns:
+            List of all public registered implementations (empty if none)
+        """
+        key: DependencyKey = make_key(interface, name)
+
+        # If we're in the middle of resolving something, allow internal access
+        if self._resolution_stack:
+            return await super().get_all_async(interface, name=name)
+
+        # External call - only return if the interface key is public
+        if key not in self._public_keys:
+            return []
+
+        # Only resolve from local bindings (don't include child modules)
+        instances: list[T] = []
+        bindings = self._bindings.get(key, [])
+        for binding in bindings:
+            instance = await binding.create_instance_async(self)
+            instances.append(instance)
+        return instances
+
     def is_public(self, interface: type[Any], name: str | None = None) -> bool:
         """Check if a dependency is public.
 

--- a/tests/test_collection_injection.py
+++ b/tests/test_collection_injection.py
@@ -1,0 +1,1278 @@
+"""Tests for collection injection feature.
+
+This module tests the ability to register multiple implementations of the same
+interface and inject them as a collection.
+"""
+
+import pytest
+
+from inversipy import (
+    AmbiguousDependencyError,
+    Container,
+    Inject,
+    Injectable,
+    InjectAll,
+    Module,
+    Named,
+    Scopes,
+    ValidationError,
+)
+
+# =============================================================================
+# Test Fixtures - Interfaces and Implementations
+# =============================================================================
+
+
+class IPlugin:
+    """Interface for plugins."""
+
+    def execute(self) -> str:
+        raise NotImplementedError
+
+
+class PluginA(IPlugin):
+    """Plugin A implementation."""
+
+    def execute(self) -> str:
+        return "PluginA"
+
+
+class PluginB(IPlugin):
+    """Plugin B implementation."""
+
+    def execute(self) -> str:
+        return "PluginB"
+
+
+class PluginC(IPlugin):
+    """Plugin C implementation."""
+
+    def execute(self) -> str:
+        return "PluginC"
+
+
+class IValidator:
+    """Interface for validators."""
+
+    def validate(self, value: str) -> bool:
+        raise NotImplementedError
+
+
+class LengthValidator(IValidator):
+    """Validates string length."""
+
+    def validate(self, value: str) -> bool:
+        return len(value) > 0
+
+
+class AlphaValidator(IValidator):
+    """Validates string contains only alpha characters."""
+
+    def validate(self, value: str) -> bool:
+        return value.isalpha()
+
+
+class IService:
+    """Generic service interface."""
+
+    pass
+
+
+class ServiceImpl(IService):
+    """Service implementation."""
+
+    pass
+
+
+class CircularA:
+    """Service A for circular dependency test."""
+
+    def __init__(self, b: "CircularB") -> None:
+        self.b = b
+
+
+class CircularB:
+    """Service B for circular dependency test."""
+
+    def __init__(self, a: CircularA) -> None:
+        self.a = a
+
+
+# =============================================================================
+# Test Classes: Accumulation Behavior
+# =============================================================================
+
+
+class TestAccumulationBehavior:
+    """Test that multiple register() calls accumulate bindings."""
+
+    def test_multiple_register_calls_accumulate(self) -> None:
+        """Multiple register() calls for same interface should accumulate."""
+        container = Container()
+        container.register(IPlugin, PluginA)
+        container.register(IPlugin, PluginB)
+        container.register(IPlugin, PluginC)
+
+        # Should have 3 implementations
+        assert container.count(IPlugin) == 3
+
+    def test_same_implementation_can_be_registered_twice(self) -> None:
+        """Same implementation can be registered multiple times."""
+        container = Container()
+        container.register(IPlugin, PluginA)
+        container.register(IPlugin, PluginA)
+
+        assert container.count(IPlugin) == 2
+
+    def test_register_returns_self_for_chaining(self) -> None:
+        """register() should return self for method chaining."""
+        container = Container()
+        result = (
+            container.register(IPlugin, PluginA)
+            .register(IPlugin, PluginB)
+            .register(IPlugin, PluginC)
+        )
+
+        assert result is container
+        assert container.count(IPlugin) == 3
+
+    def test_named_and_unnamed_registrations_are_separate(self) -> None:
+        """Named and unnamed registrations should be tracked separately."""
+        container = Container()
+        container.register(IPlugin, PluginA)  # Unnamed
+        container.register(IPlugin, PluginB, name="special")  # Named
+
+        # Unnamed count should be 1
+        assert container.count(IPlugin) == 1
+        # Named should exist separately
+        assert container.has(IPlugin, name="special")
+
+
+# =============================================================================
+# Test Classes: Single Resolution Ambiguity
+# =============================================================================
+
+
+class TestSingleResolutionAmbiguity:
+    """Test that get() raises AmbiguousDependencyError when multiple exist."""
+
+    def test_get_with_single_binding_works(self) -> None:
+        """get() with single binding should work as before."""
+        container = Container()
+        container.register(IPlugin, PluginA)
+
+        plugin = container.get(IPlugin)
+        assert isinstance(plugin, PluginA)
+        assert plugin.execute() == "PluginA"
+
+    def test_get_with_multiple_bindings_raises_ambiguous_error(self) -> None:
+        """get() with multiple bindings should raise AmbiguousDependencyError."""
+        container = Container()
+        container.register(IPlugin, PluginA)
+        container.register(IPlugin, PluginB)
+
+        with pytest.raises(AmbiguousDependencyError) as exc_info:
+            container.get(IPlugin)
+
+        assert exc_info.value.dependency_type is IPlugin
+        assert exc_info.value.count == 2
+        assert "IPlugin" in str(exc_info.value)
+        assert "2" in str(exc_info.value)
+
+    def test_get_with_name_works_when_multiple_exist(self) -> None:
+        """get() with name should work even when multiple unnamed exist."""
+        container = Container()
+        container.register(IPlugin, PluginA)
+        container.register(IPlugin, PluginB)
+        container.register(IPlugin, PluginC, name="primary")
+
+        # Named resolution should work
+        plugin = container.get(IPlugin, name="primary")
+        assert isinstance(plugin, PluginC)
+
+    def test_get_with_name_not_affected_by_unnamed_bindings(self) -> None:
+        """Named get() should not be affected by unnamed bindings count."""
+        container = Container()
+        container.register(IPlugin, PluginA)
+        container.register(IPlugin, PluginB)
+        container.register(IPlugin, PluginC, name="main")
+
+        # Should resolve the named one without ambiguity
+        plugin = container.get(IPlugin, name="main")
+        assert isinstance(plugin, PluginC)
+
+    def test_ambiguous_error_message_is_helpful(self) -> None:
+        """AmbiguousDependencyError message should suggest fixes."""
+        container = Container()
+        container.register(IPlugin, PluginA)
+        container.register(IPlugin, PluginB)
+        container.register(IPlugin, PluginC)
+
+        with pytest.raises(AmbiguousDependencyError) as exc_info:
+            container.get(IPlugin)
+
+        error_msg = str(exc_info.value)
+        # Should mention get_all()
+        assert "get_all" in error_msg.lower()
+        # Should mention using names
+        assert "name" in error_msg.lower()
+
+    def test_try_get_with_multiple_bindings_raises(self) -> None:
+        """try_get() should also raise AmbiguousDependencyError."""
+        container = Container()
+        container.register(IPlugin, PluginA)
+        container.register(IPlugin, PluginB)
+
+        # try_get should raise on ambiguity, not return None
+        with pytest.raises(AmbiguousDependencyError):
+            container.try_get(IPlugin)
+
+    def test_try_get_suppress_ambiguity_returns_none(self) -> None:
+        """try_get() with suppress_ambiguity=True should return None."""
+        container = Container()
+        container.register(IPlugin, PluginA)
+        container.register(IPlugin, PluginB)
+
+        # With suppress_ambiguity=True, should return None instead of raising
+        result = container.try_get(IPlugin, suppress_ambiguity=True)
+        assert result is None
+
+    def test_try_get_suppress_ambiguity_still_resolves_single(self) -> None:
+        """try_get() with suppress_ambiguity should still resolve single binding."""
+        container = Container()
+        container.register(IPlugin, PluginA)
+
+        result = container.try_get(IPlugin, suppress_ambiguity=True)
+        assert isinstance(result, PluginA)
+
+    @pytest.mark.asyncio
+    async def test_try_get_async_with_multiple_bindings_raises(self) -> None:
+        """try_get_async() should also raise AmbiguousDependencyError by default."""
+        container = Container()
+        container.register(IPlugin, PluginA)
+        container.register(IPlugin, PluginB)
+
+        with pytest.raises(AmbiguousDependencyError):
+            await container.try_get_async(IPlugin)
+
+    @pytest.mark.asyncio
+    async def test_try_get_async_suppress_ambiguity_returns_none(self) -> None:
+        """try_get_async() with suppress_ambiguity=True should return None."""
+        container = Container()
+        container.register(IPlugin, PluginA)
+        container.register(IPlugin, PluginB)
+
+        result = await container.try_get_async(IPlugin, suppress_ambiguity=True)
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_try_get_async_returns_none_if_not_found(self) -> None:
+        """try_get_async() should return None if dependency not found."""
+        container = Container()
+
+        result = await container.try_get_async(IPlugin)
+        assert result is None
+
+
+# =============================================================================
+# Test Classes: Collection Resolution
+# =============================================================================
+
+
+class TestCollectionResolution:
+    """Test get_all() method for resolving all implementations."""
+
+    def test_get_all_returns_all_implementations(self) -> None:
+        """get_all() should return all registered implementations."""
+        container = Container()
+        container.register(IPlugin, PluginA)
+        container.register(IPlugin, PluginB)
+        container.register(IPlugin, PluginC)
+
+        plugins = container.get_all(IPlugin)
+
+        assert len(plugins) == 3
+        assert any(isinstance(p, PluginA) for p in plugins)
+        assert any(isinstance(p, PluginB) for p in plugins)
+        assert any(isinstance(p, PluginC) for p in plugins)
+
+    def test_get_all_returns_empty_list_when_none_registered(self) -> None:
+        """get_all() should return empty list when no implementations."""
+        container = Container()
+
+        plugins = container.get_all(IPlugin)
+
+        assert plugins == []
+        assert isinstance(plugins, list)
+
+    def test_get_all_preserves_registration_order(self) -> None:
+        """get_all() should return implementations in registration order."""
+        container = Container()
+        container.register(IPlugin, PluginA)
+        container.register(IPlugin, PluginB)
+        container.register(IPlugin, PluginC)
+
+        plugins = container.get_all(IPlugin)
+
+        assert isinstance(plugins[0], PluginA)
+        assert isinstance(plugins[1], PluginB)
+        assert isinstance(plugins[2], PluginC)
+
+    def test_get_all_with_single_implementation(self) -> None:
+        """get_all() with single implementation should return list with one item."""
+        container = Container()
+        container.register(IPlugin, PluginA)
+
+        plugins = container.get_all(IPlugin)
+
+        assert len(plugins) == 1
+        assert isinstance(plugins[0], PluginA)
+
+    def test_get_all_does_not_include_named_bindings(self) -> None:
+        """get_all() should only return unnamed bindings."""
+        container = Container()
+        container.register(IPlugin, PluginA)
+        container.register(IPlugin, PluginB)
+        container.register(IPlugin, PluginC, name="special")
+
+        plugins = container.get_all(IPlugin)
+
+        assert len(plugins) == 2
+        assert not any(isinstance(p, PluginC) for p in plugins)
+
+    def test_get_all_creates_new_instances_for_transient(self) -> None:
+        """get_all() should create new instances for transient scope."""
+        container = Container()
+        container.register(IPlugin, PluginA, scope=Scopes.TRANSIENT)
+
+        plugins1 = container.get_all(IPlugin)
+        plugins2 = container.get_all(IPlugin)
+
+        assert plugins1[0] is not plugins2[0]
+
+
+# =============================================================================
+# Test Classes: Async Collection Resolution
+# =============================================================================
+
+
+class TestAsyncCollectionResolution:
+    """Test get_all_async() method."""
+
+    @pytest.mark.asyncio
+    async def test_get_all_async_returns_all_implementations(self) -> None:
+        """get_all_async() should return all registered implementations."""
+        container = Container()
+        container.register(IPlugin, PluginA)
+        container.register(IPlugin, PluginB)
+
+        plugins = await container.get_all_async(IPlugin)
+
+        assert len(plugins) == 2
+        assert any(isinstance(p, PluginA) for p in plugins)
+        assert any(isinstance(p, PluginB) for p in plugins)
+
+    @pytest.mark.asyncio
+    async def test_get_all_async_returns_empty_list_when_none(self) -> None:
+        """get_all_async() should return empty list when none registered."""
+        container = Container()
+
+        plugins = await container.get_all_async(IPlugin)
+
+        assert plugins == []
+
+    @pytest.mark.asyncio
+    async def test_get_all_async_with_async_factory(self) -> None:
+        """get_all_async() should work with async factories."""
+        container = Container()
+
+        async def create_plugin_a() -> PluginA:
+            return PluginA()
+
+        async def create_plugin_b() -> PluginB:
+            return PluginB()
+
+        container.register_factory(IPlugin, create_plugin_a)
+        container.register_factory(IPlugin, create_plugin_b)
+
+        plugins = await container.get_all_async(IPlugin)
+
+        assert len(plugins) == 2
+
+
+# =============================================================================
+# Test Classes: Scopes in Collections
+# =============================================================================
+
+
+class TestScopesInCollections:
+    """Test that scopes work correctly with collection injection."""
+
+    def test_singleton_scope_returns_same_instances(self) -> None:
+        """Singleton scoped items should return same instances across calls."""
+        container = Container()
+        container.register(IPlugin, PluginA, scope=Scopes.SINGLETON)
+        container.register(IPlugin, PluginB, scope=Scopes.SINGLETON)
+
+        plugins1 = container.get_all(IPlugin)
+        plugins2 = container.get_all(IPlugin)
+
+        assert plugins1[0] is plugins2[0]
+        assert plugins1[1] is plugins2[1]
+
+    def test_transient_scope_returns_new_instances(self) -> None:
+        """Transient scoped items should return new instances each call."""
+        container = Container()
+        container.register(IPlugin, PluginA, scope=Scopes.TRANSIENT)
+        container.register(IPlugin, PluginB, scope=Scopes.TRANSIENT)
+
+        plugins1 = container.get_all(IPlugin)
+        plugins2 = container.get_all(IPlugin)
+
+        assert plugins1[0] is not plugins2[0]
+        assert plugins1[1] is not plugins2[1]
+
+    def test_mixed_scopes_in_collection(self) -> None:
+        """Collection can have items with different scopes."""
+        container = Container()
+        container.register(IPlugin, PluginA, scope=Scopes.SINGLETON)
+        container.register(IPlugin, PluginB, scope=Scopes.TRANSIENT)
+
+        plugins1 = container.get_all(IPlugin)
+        plugins2 = container.get_all(IPlugin)
+
+        # PluginA is singleton - same instance
+        assert plugins1[0] is plugins2[0]
+        # PluginB is transient - different instances
+        assert plugins1[1] is not plugins2[1]
+
+
+# =============================================================================
+# Test Classes: InjectAll Type Alias
+# =============================================================================
+
+
+class TestInjectAllTypeAlias:
+    """Test InjectAll[T] type alias for property/constructor injection."""
+
+    def test_inject_all_property_injection(self) -> None:
+        """InjectAll should work with Injectable property injection."""
+
+        class PluginManager(Injectable):
+            plugins: InjectAll[IPlugin]
+
+            def run_all(self) -> list[str]:
+                return [p.execute() for p in self.plugins]
+
+        container = Container()
+        container.register(IPlugin, PluginA)
+        container.register(IPlugin, PluginB)
+        container.register(PluginManager)
+
+        manager = container.get(PluginManager)
+
+        assert len(manager.plugins) == 2
+        results = manager.run_all()
+        assert "PluginA" in results
+        assert "PluginB" in results
+
+    def test_inject_all_constructor_injection(self) -> None:
+        """InjectAll should work with constructor injection."""
+
+        class PluginRunner:
+            def __init__(self, plugins: InjectAll[IPlugin]) -> None:
+                self.plugins = plugins
+
+            def run_all(self) -> list[str]:
+                return [p.execute() for p in self.plugins]
+
+        container = Container()
+        container.register(IPlugin, PluginA)
+        container.register(IPlugin, PluginB)
+        container.register(PluginRunner)
+
+        runner = container.get(PluginRunner)
+
+        assert len(runner.plugins) == 2
+
+    def test_inject_all_with_empty_collection(self) -> None:
+        """InjectAll should inject empty list when no implementations."""
+
+        class OptionalPluginManager(Injectable):
+            plugins: InjectAll[IPlugin]
+
+        container = Container()
+        container.register(OptionalPluginManager)
+
+        manager = container.get(OptionalPluginManager)
+
+        assert manager.plugins == []
+        assert isinstance(manager.plugins, list)
+
+    def test_inject_all_combined_with_inject(self) -> None:
+        """InjectAll can be used alongside Inject."""
+
+        class ComplexService(Injectable):
+            plugins: InjectAll[IPlugin]
+            primary: Inject[IService]
+
+        container = Container()
+        container.register(IPlugin, PluginA)
+        container.register(IPlugin, PluginB)
+        container.register(IService, ServiceImpl)
+        container.register(ComplexService)
+
+        service = container.get(ComplexService)
+
+        assert len(service.plugins) == 2
+        assert isinstance(service.primary, ServiceImpl)
+
+    def test_inject_all_with_named_inject(self) -> None:
+        """InjectAll can be used alongside named Inject."""
+
+        class MixedService(Injectable):
+            all_plugins: InjectAll[IPlugin]
+            main_plugin: Inject[IPlugin, Named("main")]
+
+        container = Container()
+        container.register(IPlugin, PluginA)
+        container.register(IPlugin, PluginB)
+        container.register(IPlugin, PluginC, name="main")
+        container.register(MixedService)
+
+        service = container.get(MixedService)
+
+        assert len(service.all_plugins) == 2
+        assert isinstance(service.main_plugin, PluginC)
+
+
+# =============================================================================
+# Test Classes: Module Collections
+# =============================================================================
+
+
+class TestModuleCollections:
+    """Test collection injection with modules."""
+
+    def test_module_get_all_respects_public_visibility(self) -> None:
+        """Module get_all() returns empty list when key is not public."""
+        module = Module("plugins")
+        # Register all as private - key is never made public
+        module.register(IPlugin, PluginA, public=False)
+        module.register(IPlugin, PluginB, public=False)
+
+        plugins = module.get_all(IPlugin)
+
+        # No plugins returned since key is not public
+        assert len(plugins) == 0
+
+    def test_module_get_all_returns_all_when_key_public(self) -> None:
+        """Module get_all() returns all implementations when key is public."""
+        module = Module("plugins")
+        # First registration makes the key public
+        module.register(IPlugin, PluginA, public=True)
+        # Second registration - key is already public
+        module.register(IPlugin, PluginB, public=True)
+
+        plugins = module.get_all(IPlugin)
+
+        # All implementations under the public key are returned
+        assert len(plugins) == 2
+        assert isinstance(plugins[0], PluginA)
+        assert isinstance(plugins[1], PluginB)
+
+    def test_container_aggregates_from_modules(self) -> None:
+        """Container should aggregate implementations from registered modules."""
+        module = Module("plugins")
+        module.register(IPlugin, PluginA, public=True)
+        module.register(IPlugin, PluginB, public=True)
+
+        container = Container()
+        container.register(IPlugin, PluginC)
+        container.register_module(module)
+
+        plugins = container.get_all(IPlugin)
+
+        assert len(plugins) == 3
+
+    def test_container_aggregates_from_multiple_modules(self) -> None:
+        """Container should aggregate from multiple modules."""
+        module1 = Module("module1")
+        module1.register(IPlugin, PluginA, public=True)
+
+        module2 = Module("module2")
+        module2.register(IPlugin, PluginB, public=True)
+
+        container = Container()
+        container.register_module(module1)
+        container.register_module(module2)
+
+        plugins = container.get_all(IPlugin)
+
+        assert len(plugins) == 2
+
+    def test_parent_container_aggregation(self) -> None:
+        """Child container should aggregate from parent."""
+        parent = Container()
+        parent.register(IPlugin, PluginA)
+
+        child = parent.create_child()
+        child.register(IPlugin, PluginB)
+
+        plugins = child.get_all(IPlugin)
+
+        assert len(plugins) == 2
+
+    def test_module_count_only_counts_public(self) -> None:
+        """Module count() returns 0 when key is not public."""
+        module = Module("plugins")
+        # All private - key is never made public
+        module.register(IPlugin, PluginA, public=False)
+        module.register(IPlugin, PluginB, public=False)
+
+        # Module should report 0 since key is not public
+        assert module.count(IPlugin) == 0
+
+    def test_module_count_returns_all_when_key_public(self) -> None:
+        """Module count() returns count of all implementations when key is public."""
+        module = Module("plugins")
+        module.register(IPlugin, PluginA, public=True)
+        module.register(IPlugin, PluginB, public=True)
+        module.register(IPlugin, PluginC, public=True)
+
+        # Module should report all 3 since key is public
+        assert module.count(IPlugin) == 3
+
+
+# =============================================================================
+# Test Classes: Validation
+# =============================================================================
+
+
+class TestValidation:
+    """Test validation with collection injection."""
+
+    def test_validation_passes_with_inject_all_empty(self) -> None:
+        """Validation should pass when InjectAll dependency has no implementations."""
+
+        # Use regular class with constructor injection instead of Injectable
+        # to test InjectAll validation in constructor parameters
+        class OptionalPlugins:
+            def __init__(self, plugins: InjectAll[IPlugin]) -> None:
+                self.plugins = plugins
+
+        container = Container()
+        container.register(OptionalPlugins)
+
+        # Should not raise - InjectAll is always valid (returns empty list if none)
+        container.validate()
+
+    def test_validation_passes_with_injectable_inject_all(self) -> None:
+        """Validation should pass for Injectable classes with InjectAll properties."""
+
+        class PluginManager(Injectable):
+            plugins: InjectAll[IPlugin]
+
+        container = Container()
+        container.register(PluginManager)
+
+        # Should not raise - InjectAll via Injectable is always valid
+        container.validate()
+
+    def test_validation_passes_with_injectable_inject_all_named(self) -> None:
+        """Validation should pass for Injectable classes with named InjectAll."""
+
+        class PluginManager(Injectable):
+            core_plugins: InjectAll[IPlugin, Named("core")]
+
+        container = Container()
+        container.register(PluginManager)
+
+        # Should not raise - named InjectAll via Injectable is always valid
+        container.validate()
+
+    def test_validation_detects_ambiguous_dependency(self) -> None:
+        """Validation should detect ambiguous dependencies."""
+
+        class NeedsPlugin:
+            def __init__(self, plugin: IPlugin) -> None:
+                self.plugin = plugin
+
+        container = Container()
+        container.register(IPlugin, PluginA)
+        container.register(IPlugin, PluginB)
+        container.register(NeedsPlugin)
+
+        with pytest.raises(ValidationError) as exc_info:
+            container.validate()
+
+        error_msg = str(exc_info.value)
+        assert "IPlugin" in error_msg
+        assert "2" in error_msg or "multiple" in error_msg.lower()
+
+    def test_validation_error_suggests_named_or_inject_all(self) -> None:
+        """Validation error for ambiguity should suggest fixes."""
+
+        class NeedsPlugin:
+            def __init__(self, plugin: IPlugin) -> None:
+                self.plugin = plugin
+
+        container = Container()
+        container.register(IPlugin, PluginA)
+        container.register(IPlugin, PluginB)
+        container.register(NeedsPlugin)
+
+        with pytest.raises(ValidationError) as exc_info:
+            container.validate()
+
+        error_msg = str(exc_info.value)
+        # Should suggest Named() or InjectAll
+        assert "Named" in error_msg or "InjectAll" in error_msg
+
+    def test_validation_passes_with_named_dependency(self) -> None:
+        """Validation should pass when ambiguity is resolved with Named."""
+
+        class NeedsPlugin:
+            def __init__(self, plugin: Inject[IPlugin, Named("main")]) -> None:
+                self.plugin = plugin
+
+        container = Container()
+        container.register(IPlugin, PluginA)
+        container.register(IPlugin, PluginB)
+        container.register(IPlugin, PluginC, name="main")
+        container.register(NeedsPlugin)
+
+        # Should not raise - named dependency resolves ambiguity
+        container.validate()
+
+    def test_validation_passes_with_single_implementation(self) -> None:
+        """Validation should pass with single implementation (no ambiguity)."""
+
+        class NeedsPlugin:
+            def __init__(self, plugin: IPlugin) -> None:
+                self.plugin = plugin
+
+        container = Container()
+        container.register(IPlugin, PluginA)
+        container.register(NeedsPlugin)
+
+        # Should not raise - only one implementation
+        container.validate()
+
+
+# =============================================================================
+# Test Classes: Container.run() Integration
+# =============================================================================
+
+
+class TestContainerRunIntegration:
+    """Test that container.run() works with collection injection."""
+
+    def test_run_with_inject_all_parameter(self) -> None:
+        """container.run() should resolve InjectAll parameters."""
+
+        def process_plugins(plugins: InjectAll[IPlugin]) -> list[str]:
+            return [p.execute() for p in plugins]
+
+        container = Container()
+        container.register(IPlugin, PluginA)
+        container.register(IPlugin, PluginB)
+
+        results = container.run(process_plugins)
+
+        assert len(results) == 2
+        assert "PluginA" in results
+        assert "PluginB" in results
+
+    def test_run_with_ambiguous_dependency_raises(self) -> None:
+        """container.run() should raise on ambiguous dependencies."""
+
+        def process_plugin(plugin: IPlugin) -> str:
+            return plugin.execute()
+
+        container = Container()
+        container.register(IPlugin, PluginA)
+        container.register(IPlugin, PluginB)
+
+        with pytest.raises(AmbiguousDependencyError):
+            container.run(process_plugin)
+
+    @pytest.mark.asyncio
+    async def test_run_async_with_inject_all(self) -> None:
+        """container.run_async() should resolve InjectAll parameters."""
+
+        def process_plugins(plugins: InjectAll[IPlugin]) -> list[str]:
+            return [p.execute() for p in plugins]
+
+        container = Container()
+        container.register(IPlugin, PluginA)
+        container.register(IPlugin, PluginB)
+
+        results = await container.run_async(process_plugins)
+
+        assert len(results) == 2
+
+
+# =============================================================================
+# Test Classes: has() and count() Methods
+# =============================================================================
+
+
+class TestHasAndCount:
+    """Test has() and count() methods with collections."""
+
+    def test_has_returns_true_with_multiple_implementations(self) -> None:
+        """has() should return True when any implementations exist."""
+        container = Container()
+        container.register(IPlugin, PluginA)
+        container.register(IPlugin, PluginB)
+
+        assert container.has(IPlugin) is True
+
+    def test_has_returns_false_when_none_registered(self) -> None:
+        """has() should return False when no implementations."""
+        container = Container()
+
+        assert container.has(IPlugin) is False
+
+    def test_count_returns_number_of_implementations(self) -> None:
+        """count() should return the number of registered implementations."""
+        container = Container()
+
+        assert container.count(IPlugin) == 0
+
+        container.register(IPlugin, PluginA)
+        assert container.count(IPlugin) == 1
+
+        container.register(IPlugin, PluginB)
+        assert container.count(IPlugin) == 2
+
+        container.register(IPlugin, PluginC)
+        assert container.count(IPlugin) == 3
+
+    def test_count_includes_parent_implementations(self) -> None:
+        """count() should include implementations from parent container."""
+        parent = Container()
+        parent.register(IPlugin, PluginA)
+
+        child = parent.create_child()
+        child.register(IPlugin, PluginB)
+
+        assert child.count(IPlugin) == 2
+
+    def test_count_includes_module_implementations(self) -> None:
+        """count() should include public implementations from modules."""
+        module = Module("plugins")
+        module.register(IPlugin, PluginA, public=True)
+        module.register(IPlugin, PluginB, public=True)
+
+        container = Container()
+        container.register(IPlugin, PluginC)
+        container.register_module(module)
+
+        assert container.count(IPlugin) == 3
+
+
+# =============================================================================
+# Test Classes: Edge Cases
+# =============================================================================
+
+
+class TestEdgeCases:
+    """Test edge cases and special scenarios."""
+
+    def test_get_all_with_instance_registrations(self) -> None:
+        """get_all() should work with pre-created instances."""
+        instance_a = PluginA()
+        instance_b = PluginB()
+
+        container = Container()
+        container.register_instance(IPlugin, instance_a)
+        container.register_instance(IPlugin, instance_b)
+
+        plugins = container.get_all(IPlugin)
+
+        assert len(plugins) == 2
+        assert instance_a in plugins
+        assert instance_b in plugins
+
+    def test_get_all_with_factory_registrations(self) -> None:
+        """get_all() should work with factory registrations."""
+        container = Container()
+
+        def create_a() -> IPlugin:
+            return PluginA()
+
+        def create_b() -> IPlugin:
+            return PluginB()
+
+        container.register_factory(IPlugin, create_a)
+        container.register_factory(IPlugin, create_b)
+
+        plugins = container.get_all(IPlugin)
+
+        assert len(plugins) == 2
+
+    def test_get_all_with_mixed_registration_types(self) -> None:
+        """get_all() should work with mixed registration types."""
+        instance_a = PluginA()
+
+        def create_b() -> IPlugin:
+            return PluginB()
+
+        container = Container()
+        container.register_instance(IPlugin, instance_a)
+        container.register_factory(IPlugin, create_b)
+        container.register(IPlugin, PluginC)
+
+        plugins = container.get_all(IPlugin)
+
+        assert len(plugins) == 3
+
+    def test_circular_dependency_in_collection_item(self) -> None:
+        """Circular dependency in a collection item should be detected."""
+        from inversipy import CircularDependencyError
+
+        container = Container()
+        container.register(CircularA)
+        container.register(CircularB)
+
+        with pytest.raises(CircularDependencyError):
+            container.get_all(CircularA)
+
+    def test_get_async_with_multiple_bindings_raises(self) -> None:
+        """get_async() should also raise AmbiguousDependencyError."""
+
+        @pytest.mark.asyncio
+        async def test() -> None:
+            container = Container()
+            container.register(IPlugin, PluginA)
+            container.register(IPlugin, PluginB)
+
+            with pytest.raises(AmbiguousDependencyError):
+                await container.get_async(IPlugin)
+
+    def test_repr_with_multiple_bindings(self) -> None:
+        """Container repr should handle multiple bindings gracefully."""
+        container = Container()
+        container.register(IPlugin, PluginA)
+        container.register(IPlugin, PluginB)
+
+        repr_str = repr(container)
+        assert "Container" in repr_str
+
+
+# =============================================================================
+# Test Classes: Named Collection Injection
+# =============================================================================
+
+
+class TestNamedCollectionInjection:
+    """Test named collection injection feature."""
+
+    def test_get_all_with_name_returns_named_bindings(self) -> None:
+        """get_all(T, name='x') should return all bindings with that name."""
+        container = Container()
+        container.register(IPlugin, PluginA, name="core")
+        container.register(IPlugin, PluginB, name="core")
+        container.register(IPlugin, PluginC, name="optional")
+
+        core_plugins = container.get_all(IPlugin, name="core")
+
+        assert len(core_plugins) == 2
+        assert any(isinstance(p, PluginA) for p in core_plugins)
+        assert any(isinstance(p, PluginB) for p in core_plugins)
+        assert not any(isinstance(p, PluginC) for p in core_plugins)
+
+    def test_get_all_named_returns_empty_list_when_none(self) -> None:
+        """get_all(T, name='x') returns empty list when no named bindings exist."""
+        container = Container()
+        container.register(IPlugin, PluginA)  # Unnamed
+
+        plugins = container.get_all(IPlugin, name="nonexistent")
+
+        assert plugins == []
+        assert isinstance(plugins, list)
+
+    def test_get_all_named_preserves_registration_order(self) -> None:
+        """get_all(T, name='x') should preserve registration order."""
+        container = Container()
+        container.register(IPlugin, PluginA, name="ordered")
+        container.register(IPlugin, PluginB, name="ordered")
+        container.register(IPlugin, PluginC, name="ordered")
+
+        plugins = container.get_all(IPlugin, name="ordered")
+
+        assert isinstance(plugins[0], PluginA)
+        assert isinstance(plugins[1], PluginB)
+        assert isinstance(plugins[2], PluginC)
+
+    def test_get_all_named_does_not_include_unnamed(self) -> None:
+        """get_all(T, name='x') should not include unnamed bindings."""
+        container = Container()
+        container.register(IPlugin, PluginA)  # Unnamed
+        container.register(IPlugin, PluginB, name="group")
+        container.register(IPlugin, PluginC, name="group")
+
+        plugins = container.get_all(IPlugin, name="group")
+
+        assert len(plugins) == 2
+        assert not any(isinstance(p, PluginA) for p in plugins)
+
+    def test_get_all_named_does_not_include_other_names(self) -> None:
+        """get_all(T, name='x') should not include bindings with other names."""
+        container = Container()
+        container.register(IPlugin, PluginA, name="group1")
+        container.register(IPlugin, PluginB, name="group2")
+
+        plugins = container.get_all(IPlugin, name="group1")
+
+        assert len(plugins) == 1
+        assert isinstance(plugins[0], PluginA)
+
+    def test_count_with_name_returns_named_count(self) -> None:
+        """count(T, name='x') should return count of named bindings."""
+        container = Container()
+        container.register(IPlugin, PluginA, name="core")
+        container.register(IPlugin, PluginB, name="core")
+        container.register(IPlugin, PluginC)  # Unnamed
+
+        assert container.count(IPlugin, name="core") == 2
+        assert container.count(IPlugin) == 1  # Only unnamed
+
+    @pytest.mark.asyncio
+    async def test_get_all_async_with_name(self) -> None:
+        """get_all_async(T, name='x') should return all named bindings."""
+        container = Container()
+        container.register(IPlugin, PluginA, name="async_group")
+        container.register(IPlugin, PluginB, name="async_group")
+
+        plugins = await container.get_all_async(IPlugin, name="async_group")
+
+        assert len(plugins) == 2
+
+    def test_get_all_named_with_singleton_scope(self) -> None:
+        """Named collection should respect singleton scope."""
+        container = Container()
+        container.register(IPlugin, PluginA, name="single", scope=Scopes.SINGLETON)
+        container.register(IPlugin, PluginB, name="single", scope=Scopes.SINGLETON)
+
+        plugins1 = container.get_all(IPlugin, name="single")
+        plugins2 = container.get_all(IPlugin, name="single")
+
+        assert plugins1[0] is plugins2[0]
+        assert plugins1[1] is plugins2[1]
+
+    def test_get_all_named_with_transient_scope(self) -> None:
+        """Named collection should respect transient scope."""
+        container = Container()
+        container.register(IPlugin, PluginA, name="transient", scope=Scopes.TRANSIENT)
+
+        plugins1 = container.get_all(IPlugin, name="transient")
+        plugins2 = container.get_all(IPlugin, name="transient")
+
+        assert plugins1[0] is not plugins2[0]
+
+
+class TestInjectAllWithNamedTypeAlias:
+    """Test InjectAll[T, Named('x')] type alias for property/constructor injection."""
+
+    def test_inject_all_with_named_property_injection(self) -> None:
+        """InjectAll[T, Named()] should work with Injectable property injection."""
+
+        class PluginManager(Injectable):
+            core_plugins: InjectAll[IPlugin, Named("core")]
+
+            def run_core(self) -> list[str]:
+                return [p.execute() for p in self.core_plugins]
+
+        container = Container()
+        container.register(IPlugin, PluginA, name="core")
+        container.register(IPlugin, PluginB, name="core")
+        container.register(IPlugin, PluginC, name="optional")
+        container.register(PluginManager)
+
+        manager = container.get(PluginManager)
+
+        assert len(manager.core_plugins) == 2
+        results = manager.run_core()
+        assert "PluginA" in results
+        assert "PluginB" in results
+        assert "PluginC" not in results
+
+    def test_inject_all_named_constructor_injection(self) -> None:
+        """InjectAll should work with constructor injection."""
+
+        class PluginRunner:
+            def __init__(self, plugins: InjectAll[IPlugin, Named("runner")]) -> None:
+                self.plugins = plugins
+
+        container = Container()
+        container.register(IPlugin, PluginA, name="runner")
+        container.register(IPlugin, PluginB, name="runner")
+        container.register(PluginRunner)
+
+        runner = container.get(PluginRunner)
+
+        assert len(runner.plugins) == 2
+
+    def test_inject_all_named_with_empty_collection(self) -> None:
+        """InjectAll should inject empty list when no matching named bindings."""
+
+        class OptionalManager(Injectable):
+            plugins: InjectAll[IPlugin, Named("missing")]
+
+        container = Container()
+        container.register(OptionalManager)
+
+        manager = container.get(OptionalManager)
+
+        assert manager.plugins == []
+        assert isinstance(manager.plugins, list)
+
+    def test_inject_all_named_combined_with_inject_all(self) -> None:
+        """InjectAll can be used alongside InjectAll."""
+
+        class ComplexManager(Injectable):
+            all_plugins: InjectAll[IPlugin]
+            core_plugins: InjectAll[IPlugin, Named("core")]
+
+        container = Container()
+        container.register(IPlugin, PluginA)  # Unnamed
+        container.register(IPlugin, PluginB)  # Unnamed
+        container.register(IPlugin, PluginC, name="core")  # Named
+
+        # Note: Named bindings are separate from unnamed
+        container.register(IPlugin, PluginA, name="core")  # Named
+        container.register(ComplexManager)
+
+        manager = container.get(ComplexManager)
+
+        # all_plugins gets unnamed bindings
+        assert len(manager.all_plugins) == 2
+        # core_plugins gets named "core" bindings
+        assert len(manager.core_plugins) == 2
+
+    def test_inject_all_named_with_inject(self) -> None:
+        """InjectAll can be used alongside regular Inject."""
+
+        class MixedService(Injectable):
+            core_plugins: InjectAll[IPlugin, Named("core")]
+            primary: Inject[IService]
+
+        container = Container()
+        container.register(IPlugin, PluginA, name="core")
+        container.register(IPlugin, PluginB, name="core")
+        container.register(IService, ServiceImpl)
+        container.register(MixedService)
+
+        service = container.get(MixedService)
+
+        assert len(service.core_plugins) == 2
+        assert isinstance(service.primary, ServiceImpl)
+
+    def test_multiple_inject_all_named_different_groups(self) -> None:
+        """Multiple InjectAll with different groups."""
+
+        class MultiGroupManager(Injectable):
+            core_plugins: InjectAll[IPlugin, Named("core")]
+            optional_plugins: InjectAll[IPlugin, Named("optional")]
+
+        container = Container()
+        container.register(IPlugin, PluginA, name="core")
+        container.register(IPlugin, PluginB, name="core")
+        container.register(IPlugin, PluginC, name="optional")
+        container.register(MultiGroupManager)
+
+        manager = container.get(MultiGroupManager)
+
+        assert len(manager.core_plugins) == 2
+        assert len(manager.optional_plugins) == 1
+        assert isinstance(manager.optional_plugins[0], PluginC)
+
+
+class TestNamedCollectionWithModules:
+    """Test named collection injection with modules."""
+
+    def test_module_get_all_with_name(self) -> None:
+        """Module get_all(T, name='x') should work with named bindings."""
+        module = Module("plugins")
+        module.register(IPlugin, PluginA, name="core", public=True)
+        module.register(IPlugin, PluginB, name="core", public=True)
+
+        plugins = module.get_all(IPlugin, name="core")
+
+        assert len(plugins) == 2
+
+    def test_module_count_with_name(self) -> None:
+        """Module count(T, name='x') should count named bindings."""
+        module = Module("plugins")
+        module.register(IPlugin, PluginA, name="core", public=True)
+        module.register(IPlugin, PluginB, name="core", public=True)
+        module.register(IPlugin, PluginC, public=True)
+
+        assert module.count(IPlugin, name="core") == 2
+        assert module.count(IPlugin) == 1
+
+    def test_container_aggregates_named_from_modules(self) -> None:
+        """Container should aggregate named implementations from modules."""
+        module = Module("plugins")
+        module.register(IPlugin, PluginA, name="core", public=True)
+        module.register(IPlugin, PluginB, name="core", public=True)
+
+        container = Container()
+        container.register(IPlugin, PluginC, name="core")
+        container.register_module(module)
+
+        plugins = container.get_all(IPlugin, name="core")
+
+        assert len(plugins) == 3
+
+    def test_parent_container_named_aggregation(self) -> None:
+        """Child container should aggregate named bindings from parent."""
+        parent = Container()
+        parent.register(IPlugin, PluginA, name="shared")
+
+        child = parent.create_child()
+        child.register(IPlugin, PluginB, name="shared")
+
+        plugins = child.get_all(IPlugin, name="shared")
+
+        assert len(plugins) == 2
+
+
+class TestNamedCollectionContainerRun:
+    """Test container.run() with named collection injection."""
+
+    def test_run_with_inject_all_named_parameter(self) -> None:
+        """container.run() should resolve InjectAll parameters."""
+
+        def process_core(plugins: InjectAll[IPlugin, Named("core")]) -> list[str]:
+            return [p.execute() for p in plugins]
+
+        container = Container()
+        container.register(IPlugin, PluginA, name="core")
+        container.register(IPlugin, PluginB, name="core")
+        container.register(IPlugin, PluginC, name="optional")
+
+        results = container.run(process_core)
+
+        assert len(results) == 2
+        assert "PluginA" in results
+        assert "PluginB" in results
+        assert "PluginC" not in results
+
+    @pytest.mark.asyncio
+    async def test_run_async_with_inject_all_named(self) -> None:
+        """container.run_async() should resolve InjectAll parameters."""
+
+        def process_core(plugins: InjectAll[IPlugin, Named("core")]) -> list[str]:
+            return [p.execute() for p in plugins]
+
+        container = Container()
+        container.register(IPlugin, PluginA, name="core")
+        container.register(IPlugin, PluginB, name="core")
+
+        results = await container.run_async(process_core)
+
+        assert len(results) == 2


### PR DESCRIPTION
Add support for registering multiple implementations of the same interface and injecting them as a collection.

Features:
- Multiple register() calls now accumulate bindings (no overwriting)
- get_all(Interface) returns all registered implementations
- get_all(Interface, name="x") for named collection resolution
- InjectAll[T] type alias for property-based collection injection
- InjectAll[T, Named("x")] for named collection injection
- AmbiguousDependencyError when get() finds multiple implementations
- try_get() with suppress_ambiguity flag for flexible error handling
- try_get_async() for async collection resolution
- Full validation support including Injectable classes with InjectAll

API:
  container.register(IPlugin, PluginA) container.register(IPlugin, PluginB) plugins = container.get_all(IPlugin)  # [PluginA(), PluginB()]

  class PluginManager(Injectable): plugins: InjectAll[IPlugin] core: InjectAll[IPlugin, Named("core")]

Includes comprehensive test suite (81 tests) and documentation.