### PR TITLE
Refactor docs workflow to use GitHub Pages deployment action

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,10 +5,16 @@ on:
     branches: [main, master]
 
 permissions:
-  contents: write
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
 
 jobs:
-  deploy:
+  build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -21,5 +27,21 @@ jobs:
       - name: Install mkdocs-material
         run: pip install mkdocs-material
 
+      - name: Build docs
+        run: mkdocs build
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
       - name: Deploy to GitHub Pages
-        run: mkdocs gh-deploy --force
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary
Refactored the documentation deployment workflow to use GitHub's official Pages deployment action instead of mkdocs' built-in gh-deploy command. This separates the build and deployment steps into distinct jobs for better modularity and follows GitHub's recommended practices for Pages deployments.

## Key Changes
- Split the single `deploy` job into two separate jobs: `build` and `deploy`
  - `build` job: Checks out code, installs dependencies, and builds the documentation
  - `deploy` job: Handles artifact upload and deployment to GitHub Pages
- Updated permissions to align with GitHub Pages requirements:
  - Changed `contents: write` to `contents: read`
  - Added `pages: write` and `id-token: write` permissions
- Added concurrency configuration to prevent simultaneous deployments
- Replaced `mkdocs gh-deploy --force` with the official `actions/deploy-pages@v4` action
- Added `actions/upload-pages-artifact@v3` to upload the built site as an artifact
- Added environment configuration with GitHub Pages environment and URL output

## Implementation Details
- The workflow now follows the standard GitHub Pages deployment pattern with artifact-based deployment
- The `deploy` job depends on the `build` job completing successfully via the `needs` keyword
- Deployment URL is captured from the deployment action output for reference
- Concurrency settings prevent race conditions during simultaneous workflow runs

https://claude.ai/code/session_01G38f17cJRaJRUpGygHKuAT