### PR TITLE
Add Flask, Click, and Pytest integration documentation

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -52,6 +52,9 @@ nav:
     - Optional Dependencies: injection/optional.md
   - Integrations:
     - FastAPI: integrations/fastapi.md
+    - Flask: integrations/flask.md
+    - Click: integrations/click.md
+    - Pytest: integrations/pytest.md
   - Advanced:
     - Validation: advanced/validation.md
     - Container Freezing: advanced/freezing.md


### PR DESCRIPTION
## Summary
This PR adds documentation entries for three new framework integrations to the mkdocs navigation structure.

## Changes
- Added Flask integration documentation link (`integrations/flask.md`)
- Added Click integration documentation link (`integrations/click.md`)
- Added Pytest integration documentation link (`integrations/pytest.md`)

These new integration guides are now included in the Integrations section of the documentation navigation, alongside the existing FastAPI integration documentation.

https://claude.ai/code/session_01Ko428zqy2gNuPeiVxYZen5