### PR TITLE
Add test result reporting to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,14 @@ jobs:
         run: uv sync
 
       - name: Run tests with coverage
-        run: uv run pytest tests/ -v --tb=short --cov --cov-report=term-missing --cov-report=xml
+        run: uv run pytest tests/ -v --tb=short --cov --cov-report=term-missing --cov-report=xml --junitxml=test-results.xml
+
+      - name: Upload test results
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results-${{ matrix.python-version }}
+          path: test-results.xml
 
       - name: Upload coverage to Codecov
         if: matrix.python-version == '3.13'
@@ -82,10 +89,40 @@ jobs:
           files: coverage.xml
           token: ${{ secrets.CODECOV_TOKEN }}
 
+  test-report:
+    name: Test Report
+    if: ${{ !cancelled() }}
+    needs: [test]
+    runs-on: ubuntu-latest
+    permissions:
+      checks: write
+      pull-requests: write
+      contents: read
+      actions: read
+    steps:
+      - name: Download test results
+        uses: actions/download-artifact@v4
+        with:
+          pattern: test-results-*
+          merge-multiple: true
+
+      - name: Convert JUnit XML to CTRF
+        run: npx junit-to-ctrf "*.xml" -o ctrf/ctrf-report.json
+
+      - name: Publish test report
+        uses: ctrf-io/github-test-reporter@v1
+        with:
+          report-path: "ctrf/*.json"
+          summary: true
+          pull-request-report: true
+          annotate: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   ci:
     name: CI
     if: always()
-    needs: [lint, typecheck, test]
+    needs: [lint, typecheck, test, test-report]
     runs-on: ubuntu-latest
     steps:
       - name: Check results


### PR DESCRIPTION
## Summary
Enhanced the CI workflow to capture and report test results with detailed annotations in pull requests.

## Key Changes
- **Test result collection**: Modified the pytest command to generate JUnit XML output (`test-results.xml`)
- **Artifact upload**: Added step to upload test results as workflow artifacts, organized by Python version
- **Test report job**: Created new `test-report` job that:
  - Downloads all test result artifacts from the test matrix
  - Converts JUnit XML format to CTRF (Common Test Report Format)
  - Publishes a comprehensive test report with PR annotations and summary
- **Workflow dependencies**: Updated the final `ci` job to depend on the new `test-report` job

## Implementation Details
- Test results are uploaded unconditionally (`if: !cancelled()`) to ensure they're captured even if tests fail
- The test report job uses `pattern: test-results-*` with `merge-multiple: true` to combine results from all Python versions tested in the matrix
- Report includes pull request annotations and summary for better visibility of test outcomes
- Proper permissions are set for the test report job (checks, pull-requests, contents, actions)

https://claude.ai/code/session_011wpuihTzBPX4BPtTPs7sYX