### PR TITLE
Add explicit permissions to CI workflow job

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,6 +9,11 @@ jobs:
   ci:
     name: CI Checks
     uses: ./.github/workflows/ci.yml
+    permissions:
+      actions: read
+      checks: write
+      pull-requests: write
+      contents: read
 
   build:
     name: Build Package


### PR DESCRIPTION
## Summary
Added explicit permission declarations to the CI job in the publish workflow to follow the principle of least privilege and improve workflow security.

## Key Changes
- Added `permissions` block to the CI job with the following scopes:
  - `actions: read` - Read access to GitHub Actions
  - `checks: write` - Write access to check runs and annotations
  - `pull-requests: write` - Write access to pull request comments and reviews
  - `contents: read` - Read access to repository contents

## Implementation Details
These permissions enable the CI workflow to properly report check results and interact with pull requests while maintaining explicit access control. This follows GitHub's security best practices by avoiding the use of default broad permissions.

https://claude.ai/code/session_01YWz9anxkcDzVMNuXiCipFV