### PR TITLE
refactor: centralize dependency resolution loop

### DIFF
--- a/inversipy/container.py
+++ b/inversipy/container.py
@@ -96,6 +96,83 @@ def _make_wrapper(
     return Lazy(resolver)
 
 
+def _make_wrapper_async(
+    wrapper_type: type, dep_type: type, dep_name: str | None, container: "Container"
+) -> Factory | Lazy:  # type: ignore[type-arg]
+    """Create a Factory or Lazy wrapper with async resolution support."""
+
+    def sync_resolver(_t: type = dep_type, _n: str | None = dep_name) -> Any:
+        return container.get(_t, name=_n)
+
+    async def async_resolver(_t: type = dep_type, _n: str | None = dep_name) -> Any:
+        return await container.get_async(_t, name=_n)
+
+    if wrapper_type is Factory:
+        return Factory(sync_resolver, async_resolver)
+
+    key = make_key(dep_type, dep_name)
+    binding = container._find_binding(key)
+    if binding is not None:
+        return binding.create_lazy_wrapper_async(container, dep_type, dep_name)
+    return Lazy(sync_resolver, async_resolver)
+
+
+def _injectable_to_param_deps(cls: type[Any]) -> tuple[ParameterDependency, ...] | None:
+    """Convert Injectable field metadata into ParameterDependency tuples.
+
+    Returns None if the class has no Injectable fields.
+    """
+    inject_fields: dict[str, tuple[type, str | None]] | None = getattr(cls, "_inject_fields", None)
+    inject_all_fields: dict[str, tuple[type, str | None]] | None = getattr(
+        cls, "_inject_all_fields", None
+    )
+
+    if not inject_fields and not inject_all_fields:
+        return None
+
+    deps: list[ParameterDependency] = []
+
+    if inject_fields:
+        for field_name, (field_type, dep_name) in inject_fields.items():
+            wrapper = _extract_wrapper_type(field_type)
+            if wrapper is not None:
+                inner_type, wrapper_cls = wrapper
+                deps.append(
+                    ParameterDependency(
+                        name=field_name,
+                        dep_type=inner_type,
+                        dep_name=dep_name,
+                        is_collection=False,
+                        has_default=False,
+                        wrapper_type=wrapper_cls,
+                    )
+                )
+            else:
+                deps.append(
+                    ParameterDependency(
+                        name=field_name,
+                        dep_type=field_type,
+                        dep_name=dep_name,
+                        is_collection=False,
+                        has_default=False,
+                    )
+                )
+
+    if inject_all_fields:
+        for field_name, (item_type, coll_name) in inject_all_fields.items():
+            deps.append(
+                ParameterDependency(
+                    name=field_name,
+                    dep_type=item_type,
+                    dep_name=coll_name,
+                    is_collection=True,
+                    has_default=False,
+                )
+            )
+
+    return tuple(deps)
+
+
 def _extract_wrapper_type(annotation: Any) -> tuple[type, type] | None:
     """Extract T and wrapper class from Factory[T] or Lazy[T] annotations.
 
@@ -307,6 +384,22 @@ class Binding:
 
         return self._lazy_strategy.get(wrapper_factory, is_async_factory=False)  # type: ignore[no-any-return]
 
+    def create_lazy_wrapper_async(
+        self, container: "Container", dep_type: type, dep_name: str | None
+    ) -> "Lazy[Any]":
+        """Create a Lazy wrapper with async support, cached via scope strategy."""
+
+        def wrapper_factory() -> Lazy[Any]:
+            def resolver(_t: type = dep_type, _n: str | None = dep_name) -> Any:
+                return container.get(_t, name=_n)
+
+            async def async_resolver(_t: type = dep_type, _n: str | None = dep_name) -> Any:
+                return await container.get_async(_t, name=_n)
+
+            return Lazy(resolver, async_resolver)
+
+        return self._lazy_strategy.get(wrapper_factory, is_async_factory=False)  # type: ignore[no-any-return]
+
     def create_instance(self, container: "Container") -> Any:
         """Create an instance of the dependency (sync context)."""
         if self.instance is not None:
@@ -336,36 +429,7 @@ class Binding:
         """Call a factory function, resolving its dependencies from the container."""
         try:
             deps = analyze_parameters(factory)
-            kwargs: dict[str, Any] = {}
-
-            for dep in deps:
-                if dep.dep_type is _MissingType:
-                    raise ResolutionError(
-                        f"Factory parameter '{dep.name}' has no type hint "
-                        f"and no default value for {self.key}"
-                    )
-
-                if dep.wrapper_type is not None:
-                    kwargs[dep.name] = _make_wrapper(
-                        dep.wrapper_type, dep.dep_type, dep.dep_name, container
-                    )
-                    continue
-
-                try:
-                    if dep.is_collection:
-                        kwargs[dep.name] = container.get_all(dep.dep_type, name=dep.dep_name)
-                    else:
-                        kwargs[dep.name] = container.get(dep.dep_type, name=dep.dep_name)
-                except DependencyNotFoundError:
-                    if dep.is_optional:
-                        kwargs[dep.name] = None
-                    elif not dep.has_default:
-                        raise ResolutionError(
-                            f"Cannot resolve factory parameter '{dep.name}' "
-                            f"of type {_format_dependency(dep.dep_type, dep.dep_name)} "
-                            f"for {self.key}"
-                        )
-
+            kwargs = container._resolve_deps(deps, f"factory for {self.key}")
             return factory(**kwargs)
         except Exception as e:
             if isinstance(e, (ResolutionError, DependencyNotFoundError, CircularDependencyError)):
@@ -403,40 +467,7 @@ class Binding:
         """Call a factory function asynchronously, resolving dependencies."""
         try:
             deps = analyze_parameters(factory)
-            kwargs: dict[str, Any] = {}
-
-            for dep in deps:
-                if dep.dep_type is _MissingType:
-                    raise ResolutionError(
-                        f"Factory parameter '{dep.name}' has no type hint "
-                        f"and no default value for {self.key}"
-                    )
-
-                if dep.wrapper_type is not None:
-                    kwargs[dep.name] = _make_wrapper(
-                        dep.wrapper_type, dep.dep_type, dep.dep_name, container
-                    )
-                    continue
-
-                try:
-                    if dep.is_collection:
-                        kwargs[dep.name] = await container.get_all_async(
-                            dep.dep_type, name=dep.dep_name
-                        )
-                    else:
-                        kwargs[dep.name] = await container.get_async(
-                            dep.dep_type, name=dep.dep_name
-                        )
-                except DependencyNotFoundError:
-                    if dep.is_optional:
-                        kwargs[dep.name] = None
-                    elif not dep.has_default:
-                        raise ResolutionError(
-                            f"Cannot resolve factory parameter '{dep.name}' "
-                            f"of type {_format_dependency(dep.dep_type, dep.dep_name)} "
-                            f"for {self.key}"
-                        )
-
+            kwargs = await container._resolve_deps_async(deps, f"factory for {self.key}")
             result = factory(**kwargs)
             if asyncio.iscoroutine(result):
                 return await result
@@ -579,8 +610,9 @@ class Container:
         key = make_key(interface, name)
 
         if key in self._resolution_stack:
-            self._resolution_stack.append(key)
-            cycle_types = [get_type_from_key(k) for k in self._resolution_stack]
+            cycle_types = [get_type_from_key(k) for k in self._resolution_stack] + [
+                get_type_from_key(key)
+            ]
             raise CircularDependencyError(cycle_types)
 
         bindings = self._bindings.get(key, [])
@@ -652,8 +684,9 @@ class Container:
         key = make_key(interface, name)
 
         if key in self._resolution_stack:
-            self._resolution_stack.append(key)
-            cycle_types = [get_type_from_key(k) for k in self._resolution_stack]
+            cycle_types = [get_type_from_key(k) for k in self._resolution_stack] + [
+                get_type_from_key(key)
+            ]
             raise CircularDependencyError(cycle_types)
 
         bindings = self._bindings.get(key, [])
@@ -778,45 +811,85 @@ class Container:
 
         return instances
 
+    def _resolve_deps(
+        self,
+        deps: tuple[ParameterDependency, ...],
+        target_name: str,
+        provided: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Resolve a list of parameter dependencies synchronously."""
+        kwargs = dict(provided) if provided else {}
+        for dep in deps:
+            if dep.name in kwargs:
+                continue
+            if dep.dep_type is _MissingType:
+                raise ResolutionError(
+                    f"Parameter '{dep.name}' of {target_name} "
+                    f"has no type hint and no default value"
+                )
+            if dep.wrapper_type is not None:
+                kwargs[dep.name] = _make_wrapper(dep.wrapper_type, dep.dep_type, dep.dep_name, self)
+                continue
+            try:
+                if dep.is_collection:
+                    kwargs[dep.name] = self.get_all(dep.dep_type, name=dep.dep_name)
+                else:
+                    kwargs[dep.name] = self.get(dep.dep_type, name=dep.dep_name)
+            except DependencyNotFoundError:
+                if dep.is_optional:
+                    kwargs[dep.name] = None
+                elif not dep.has_default:
+                    raise ResolutionError(
+                        f"Cannot resolve parameter '{dep.name}' of type "
+                        f"{_format_dependency(dep.dep_type, dep.dep_name)} "
+                        f"for {target_name}"
+                    )
+        return kwargs
+
+    async def _resolve_deps_async(
+        self,
+        deps: tuple[ParameterDependency, ...],
+        target_name: str,
+        provided: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Resolve a list of parameter dependencies asynchronously."""
+        kwargs = dict(provided) if provided else {}
+        for dep in deps:
+            if dep.name in kwargs:
+                continue
+            if dep.dep_type is _MissingType:
+                raise ResolutionError(
+                    f"Parameter '{dep.name}' of {target_name} "
+                    f"has no type hint and no default value"
+                )
+            if dep.wrapper_type is not None:
+                kwargs[dep.name] = _make_wrapper_async(
+                    dep.wrapper_type, dep.dep_type, dep.dep_name, self
+                )
+                continue
+            try:
+                if dep.is_collection:
+                    kwargs[dep.name] = await self.get_all_async(dep.dep_type, name=dep.dep_name)
+                else:
+                    kwargs[dep.name] = await self.get_async(dep.dep_type, name=dep.dep_name)
+            except DependencyNotFoundError:
+                if dep.is_optional:
+                    kwargs[dep.name] = None
+                elif not dep.has_default:
+                    raise ResolutionError(
+                        f"Cannot resolve parameter '{dep.name}' of type "
+                        f"{_format_dependency(dep.dep_type, dep.dep_name)} "
+                        f"for {target_name}"
+                    )
+        return kwargs
+
     def run[T](self, func: Callable[..., T], **provided_kwargs: Any) -> T:
         """Run a function with dependency injection using synchronous resolution."""
         try:
             deps = analyze_parameters(func)
-            resolved_kwargs = provided_kwargs.copy()
-
-            for dep in deps:
-                if dep.name in provided_kwargs:
-                    continue
-
-                if dep.dep_type is _MissingType:
-                    raise ResolutionError(
-                        f"Parameter '{dep.name}' of function '{func.__name__}' "
-                        f"has no type annotation and no default value"
-                    )
-
-                if dep.wrapper_type is not None:
-                    resolved_kwargs[dep.name] = _make_wrapper(
-                        dep.wrapper_type, dep.dep_type, dep.dep_name, self
-                    )
-                    continue
-
-                try:
-                    if dep.is_collection:
-                        resolved_kwargs[dep.name] = self.get_all(dep.dep_type, name=dep.dep_name)
-                    else:
-                        resolved_kwargs[dep.name] = self.get(dep.dep_type, name=dep.dep_name)
-                except DependencyNotFoundError:
-                    if dep.is_optional:
-                        resolved_kwargs[dep.name] = None
-                    elif not dep.has_default:
-                        raise ResolutionError(
-                            f"Cannot resolve parameter '{dep.name}' of type "
-                            f"{_format_dependency(dep.dep_type, dep.dep_name)} "
-                            f"for function '{func.__name__}'"
-                        )
-
+            target = f"function '{func.__name__}'"
+            resolved_kwargs = self._resolve_deps(deps, target, provided=provided_kwargs)
             return func(**resolved_kwargs)
-
         except Exception as e:
             resolution_errors = (
                 ResolutionError,
@@ -832,45 +905,9 @@ class Container:
         """Run a function with dependency injection using asynchronous resolution."""
         try:
             deps = analyze_parameters(func)
-            resolved_kwargs = provided_kwargs.copy()
-
-            for dep in deps:
-                if dep.name in provided_kwargs:
-                    continue
-
-                if dep.dep_type is _MissingType:
-                    raise ResolutionError(
-                        f"Parameter '{dep.name}' of function '{func.__name__}' "
-                        f"has no type annotation and no default value"
-                    )
-
-                if dep.wrapper_type is not None:
-                    resolved_kwargs[dep.name] = _make_wrapper(
-                        dep.wrapper_type, dep.dep_type, dep.dep_name, self
-                    )
-                    continue
-
-                try:
-                    if dep.is_collection:
-                        resolved_kwargs[dep.name] = await self.get_all_async(
-                            dep.dep_type, name=dep.dep_name
-                        )
-                    else:
-                        resolved_kwargs[dep.name] = await self.get_async(
-                            dep.dep_type, name=dep.dep_name
-                        )
-                except DependencyNotFoundError:
-                    if dep.is_optional:
-                        resolved_kwargs[dep.name] = None
-                    elif not dep.has_default:
-                        raise ResolutionError(
-                            f"Cannot resolve parameter '{dep.name}' of type "
-                            f"{_format_dependency(dep.dep_type, dep.dep_name)} "
-                            f"for function '{func.__name__}'"
-                        )
-
+            target = f"function '{func.__name__}'"
+            resolved_kwargs = await self._resolve_deps_async(deps, target, provided=provided_kwargs)
             return func(**resolved_kwargs)
-
         except Exception as e:
             resolution_errors = (
                 ResolutionError,
@@ -889,121 +926,34 @@ class Container:
 
         Returns (inject_kwargs, inject_all_kwargs) or None if not Injectable.
         """
-        inject_fields: dict[str, tuple[type, str | None]] | None = getattr(
-            cls, "_inject_fields", None
-        )
-        inject_all_fields: dict[str, tuple[type, str | None]] | None = getattr(
-            cls, "_inject_all_fields", None
-        )
-
-        if not inject_fields and not inject_all_fields:
+        deps = _injectable_to_param_deps(cls)
+        if deps is None:
             return None
-
-        kwargs: dict[str, Any] = {}
-
-        if inject_fields:
-            for field_name, (field_type, dep_name) in inject_fields.items():
-                wrapper = _extract_wrapper_type(field_type)
-                if wrapper is not None:
-                    inner_type, wrapper_cls = wrapper
-                    kwargs[field_name] = _make_wrapper(wrapper_cls, inner_type, dep_name, self)
-                else:
-                    try:
-                        kwargs[field_name] = self.get(field_type, name=dep_name)
-                    except DependencyNotFoundError:
-                        raise ResolutionError(
-                            f"Cannot resolve dependency '{field_name}' of type "
-                            f"{_format_dependency(field_type, dep_name)} "
-                            f"for class '{cls.__name__}'"
-                        )
-
-        if inject_all_fields:
-            for field_name, (item_type, coll_name) in inject_all_fields.items():
-                kwargs[field_name] = self.get_all(item_type, name=coll_name)
-
-        return kwargs, {}
+        target = f"class '{cls.__name__}'"
+        return self._resolve_deps(deps, target), {}
 
     async def _resolve_injectable_deps_async(
         self, cls: type[Any]
     ) -> tuple[dict[str, Any], dict[str, Any]] | None:
         """Resolve dependencies for Injectable classes asynchronously."""
-        inject_fields: dict[str, tuple[type, str | None]] | None = getattr(
-            cls, "_inject_fields", None
-        )
-        inject_all_fields: dict[str, tuple[type, str | None]] | None = getattr(
-            cls, "_inject_all_fields", None
-        )
-
-        if not inject_fields and not inject_all_fields:
+        deps = _injectable_to_param_deps(cls)
+        if deps is None:
             return None
-
-        kwargs: dict[str, Any] = {}
-
-        if inject_fields:
-            for field_name, (field_type, dep_name) in inject_fields.items():
-                wrapper = _extract_wrapper_type(field_type)
-                if wrapper is not None:
-                    inner_type, wrapper_cls = wrapper
-                    kwargs[field_name] = _make_wrapper(wrapper_cls, inner_type, dep_name, self)
-                else:
-                    try:
-                        kwargs[field_name] = await self.get_async(field_type, name=dep_name)
-                    except DependencyNotFoundError:
-                        raise ResolutionError(
-                            f"Cannot resolve dependency '{field_name}' of type "
-                            f"{_format_dependency(field_type, dep_name)} "
-                            f"for class '{cls.__name__}'"
-                        )
-
-        if inject_all_fields:
-            for field_name, (item_type, coll_name) in inject_all_fields.items():
-                kwargs[field_name] = await self.get_all_async(item_type, name=coll_name)
-
-        return kwargs, {}
+        target = f"class '{cls.__name__}'"
+        return await self._resolve_deps_async(deps, target), {}
 
     def _create_instance[T](self, cls: type[T]) -> T:
         """Create an instance of a class, resolving its dependencies."""
         try:
-            # Check if this is an Injectable class
             injectable_result = self._resolve_injectable_deps(cls)
             if injectable_result is not None:
                 injectable_kwargs, _ = injectable_result
                 return cls(**injectable_kwargs)
 
-            # Regular class - use constructor inspection
             deps = analyze_parameters(cls.__init__, skip_self=True)
-            kwargs: dict[str, Any] = {}
-
-            for dep in deps:
-                if dep.dep_type is _MissingType:
-                    raise ResolutionError(
-                        f"Parameter '{dep.name}' of class '{cls.__name__}' "
-                        f"has no type annotation and no default value"
-                    )
-
-                if dep.wrapper_type is not None:
-                    kwargs[dep.name] = _make_wrapper(
-                        dep.wrapper_type, dep.dep_type, dep.dep_name, self
-                    )
-                    continue
-
-                try:
-                    if dep.is_collection:
-                        kwargs[dep.name] = self.get_all(dep.dep_type, name=dep.dep_name)
-                    else:
-                        kwargs[dep.name] = self.get(dep.dep_type, name=dep.dep_name)
-                except DependencyNotFoundError:
-                    if dep.is_optional:
-                        kwargs[dep.name] = None
-                    elif not dep.has_default:
-                        raise ResolutionError(
-                            f"Cannot resolve parameter '{dep.name}' of type "
-                            f"{_format_dependency(dep.dep_type, dep.dep_name)} "
-                            f"for class '{cls.__name__}'"
-                        )
-
+            target = f"class '{cls.__name__}'"
+            kwargs = self._resolve_deps(deps, target)
             return cls(**kwargs)
-
         except Exception as e:
             if isinstance(e, (ResolutionError, DependencyNotFoundError, CircularDependencyError)):
                 raise
@@ -1012,46 +962,15 @@ class Container:
     async def _create_instance_async[T](self, cls: type[T]) -> T:
         """Create an instance of a class asynchronously, resolving its dependencies."""
         try:
-            # Check if this is an Injectable class
             injectable_result = await self._resolve_injectable_deps_async(cls)
             if injectable_result is not None:
                 injectable_kwargs, _ = injectable_result
                 return cls(**injectable_kwargs)
 
-            # Regular class - use constructor inspection
             deps = analyze_parameters(cls.__init__, skip_self=True)
-            kwargs: dict[str, Any] = {}
-
-            for dep in deps:
-                if dep.dep_type is _MissingType:
-                    raise ResolutionError(
-                        f"Parameter '{dep.name}' of class '{cls.__name__}' "
-                        f"has no type annotation and no default value"
-                    )
-
-                if dep.wrapper_type is not None:
-                    kwargs[dep.name] = _make_wrapper(
-                        dep.wrapper_type, dep.dep_type, dep.dep_name, self
-                    )
-                    continue
-
-                try:
-                    if dep.is_collection:
-                        kwargs[dep.name] = await self.get_all_async(dep.dep_type, name=dep.dep_name)
-                    else:
-                        kwargs[dep.name] = await self.get_async(dep.dep_type, name=dep.dep_name)
-                except DependencyNotFoundError:
-                    if dep.is_optional:
-                        kwargs[dep.name] = None
-                    elif not dep.has_default:
-                        raise ResolutionError(
-                            f"Cannot resolve parameter '{dep.name}' of type "
-                            f"{_format_dependency(dep.dep_type, dep.dep_name)} "
-                            f"for class '{cls.__name__}'"
-                        )
-
+            target = f"class '{cls.__name__}'"
+            kwargs = await self._resolve_deps_async(deps, target)
             return cls(**kwargs)
-
         except Exception as e:
             if isinstance(e, (ResolutionError, DependencyNotFoundError, CircularDependencyError)):
                 raise

--- a/inversipy/types.py
+++ b/inversipy/types.py
@@ -12,12 +12,23 @@ class Factory[T]:
     Each call resolves T from the container, respecting registered scopes.
     """
 
-    __slots__ = ("_resolver",)
+    __slots__ = ("_resolver", "_async_resolver")
 
-    def __init__(self, resolver: Callable[[], T]) -> None:
+    def __init__(
+        self,
+        resolver: Callable[[], T],
+        async_resolver: Callable[[], Any] | None = None,
+    ) -> None:
         self._resolver = resolver
+        self._async_resolver = async_resolver
 
     def __call__(self) -> T:
+        return self._resolver()
+
+    async def acall(self) -> T:
+        """Resolve T asynchronously."""
+        if self._async_resolver is not None:
+            return await self._async_resolver()  # type: ignore[no-any-return]
         return self._resolver()
 
 
@@ -27,16 +38,31 @@ class Lazy[T]:
     First call resolves T from the container. Subsequent calls return the cached instance.
     """
 
-    __slots__ = ("_resolver", "_value", "_resolved")
+    __slots__ = ("_resolver", "_async_resolver", "_value", "_resolved")
 
-    def __init__(self, resolver: Callable[[], T]) -> None:
+    def __init__(
+        self,
+        resolver: Callable[[], T],
+        async_resolver: Callable[[], Any] | None = None,
+    ) -> None:
         self._resolver = resolver
+        self._async_resolver = async_resolver
         self._value: T | None = None
         self._resolved = False
 
     def __call__(self) -> T:
         if not self._resolved:
             self._value = self._resolver()
+            self._resolved = True
+        return self._value  # type: ignore[return-value]
+
+    async def acall(self) -> T:
+        """Resolve T asynchronously, caching the result."""
+        if not self._resolved:
+            if self._async_resolver is not None:
+                self._value = await self._async_resolver()
+            else:
+                self._value = self._resolver()
             self._resolved = True
         return self._value  # type: ignore[return-value]
 

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -280,7 +280,7 @@ class TestFactoryDependencyInjection:
         with pytest.raises(ResolutionError) as exc_info:
             container.get(DependentService)
 
-        assert "Cannot resolve factory parameter 'simple'" in str(exc_info.value)
+        assert "Cannot resolve parameter 'simple'" in str(exc_info.value)
 
     def test_factory_without_type_hint_raises_error(self) -> None:
         """Test that factory parameter without type hint raises error."""

--- a/tests/test_factory_lazy.py
+++ b/tests/test_factory_lazy.py
@@ -6,6 +6,7 @@ from abc import ABC, abstractmethod
 import pytest
 
 from inversipy import (
+    CircularDependencyError,
     Container,
     DependencyNotFoundError,
     Factory,
@@ -263,3 +264,208 @@ class TestLazy:
         dep = container.get(DependentWithLazy)
         with pytest.raises((DependencyNotFoundError, ResolutionError)):
             dep.lazy()
+
+
+class TestFactoryAcall:
+    def test_acall_uses_async_resolver(self) -> None:
+        """Test that Factory.acall() uses the async resolver when provided."""
+        container = Container()
+        container.register(SimpleService)
+        container.register(DependentService)
+
+        async def run() -> SimpleService:
+            dep = await container.get_async(DependentService)
+            return await dep.factory.acall()
+
+        instance = asyncio.run(run())
+        assert isinstance(instance, SimpleService)
+
+    def test_acall_falls_back_to_sync(self) -> None:
+        """Test that Factory.acall() falls back to sync resolver when no async resolver."""
+        container = Container()
+        container.register(SimpleService)
+        container.register(DependentService)
+
+        # Sync resolution produces Factory without async_resolver
+        dep = container.get(DependentService)
+
+        async def run() -> SimpleService:
+            return await dep.factory.acall()
+
+        instance = asyncio.run(run())
+        assert isinstance(instance, SimpleService)
+
+    def test_acall_resolves_fresh_each_time(self) -> None:
+        """Test that Factory.acall() resolves a new instance each call (transient)."""
+        container = Container()
+        container.register(SimpleService)
+        container.register(DependentService)
+
+        async def run() -> tuple[SimpleService, SimpleService]:
+            dep = await container.get_async(DependentService)
+            a = await dep.factory.acall()
+            b = await dep.factory.acall()
+            return a, b
+
+        a, b = asyncio.run(run())
+        assert isinstance(a, SimpleService)
+        assert a is not b
+
+
+class TestLazyAcall:
+    def test_acall_uses_async_resolver(self) -> None:
+        """Test that Lazy.acall() uses the async resolver when provided."""
+        container = Container()
+        container.register(SimpleService)
+        container.register(DependentWithLazy)
+
+        async def run() -> SimpleService:
+            dep = await container.get_async(DependentWithLazy)
+            return await dep.lazy.acall()
+
+        instance = asyncio.run(run())
+        assert isinstance(instance, SimpleService)
+
+    def test_acall_caches_result(self) -> None:
+        """Test that Lazy.acall() caches the resolved instance."""
+        container = Container()
+        container.register(SimpleService)
+        container.register(DependentWithLazy)
+
+        async def run() -> tuple[SimpleService, SimpleService]:
+            dep = await container.get_async(DependentWithLazy)
+            a = await dep.lazy.acall()
+            b = await dep.lazy.acall()
+            return a, b
+
+        a, b = asyncio.run(run())
+        assert a is b
+
+    def test_acall_falls_back_to_sync(self) -> None:
+        """Test that Lazy.acall() falls back to sync resolver when no async resolver."""
+        container = Container()
+        container.register(SimpleService)
+        container.register(DependentWithLazy)
+
+        # Sync resolution produces Lazy without async_resolver
+        dep = container.get(DependentWithLazy)
+
+        async def run() -> SimpleService:
+            return await dep.lazy.acall()
+
+        instance = asyncio.run(run())
+        assert isinstance(instance, SimpleService)
+
+
+class TestAsyncResolutionEdgeCases:
+    def test_run_async_skips_provided_kwargs(self) -> None:
+        """Test that _resolve_deps_async skips already-provided kwargs."""
+        container = Container()
+        container.register(SimpleService)
+
+        def func(svc: SimpleService) -> SimpleService:
+            return svc
+
+        provided = SimpleService()
+
+        async def run() -> SimpleService:
+            return await container.run_async(func, svc=provided)
+
+        result = asyncio.run(run())
+        assert result is provided
+
+    def test_run_async_missing_type_hint_raises(self) -> None:
+        """Test that _resolve_deps_async raises on missing type hint."""
+        container = Container()
+
+        def func(param) -> None:  # type: ignore[no-untyped-def]
+            pass
+
+        async def run() -> None:
+            await container.run_async(func)
+
+        with pytest.raises(ResolutionError, match="has no type hint"):
+            asyncio.run(run())
+
+    def test_run_async_missing_required_dep_raises(self) -> None:
+        """Test that _resolve_deps_async raises on missing required dependency."""
+        container = Container()
+
+        def func(svc: SimpleService) -> None:
+            pass
+
+        async def run() -> None:
+            await container.run_async(func)
+
+        with pytest.raises(ResolutionError, match="Cannot resolve parameter"):
+            asyncio.run(run())
+
+    def test_async_lazy_without_binding_gets_async_resolver(self) -> None:
+        """Test _make_wrapper_async Lazy fallback when no binding exists."""
+        container = Container()
+        # Register IService with multiple implementations so _find_binding
+        # returns None (it only returns for single bindings)
+        container.register(IService, ServiceA, name="a")
+        container.register(IService, ServiceB, name="b")
+
+        class Holder:
+            def __init__(self, lazy: Lazy[IService]) -> None:
+                self.lazy = lazy
+
+        # Use a factory that takes Lazy[IService] (unnamed) — no single binding
+        # exists, so _make_wrapper_async hits the fallback path
+        def create_holder(lazy: Lazy[IService]) -> Holder:
+            return Holder(lazy)
+
+        container.register_factory(Holder, create_holder)
+
+        async def run() -> Holder:
+            return await container.get_async(Holder)
+
+        # The Lazy is created but calling it will fail since IService
+        # (unnamed) has no single binding. We just need to verify the
+        # wrapper was created with async support.
+        holder = asyncio.run(run())
+        assert holder.lazy._async_resolver is not None
+
+
+class _CircA:
+    def __init__(self, b: "_CircB") -> None:
+        self.b = b
+
+
+class _CircB:
+    def __init__(self, a: _CircA) -> None:
+        self.a = a
+
+
+class TestCircularDependencyStackCleanup:
+    def test_stack_not_leaked_on_circular_dependency(self) -> None:
+        """Test that the resolution stack is not corrupted by circular dependency detection."""
+        container = Container()
+        container.register(_CircA)
+        container.register(_CircB)
+
+        with pytest.raises(CircularDependencyError):
+            container.get(_CircA)
+
+        # After the error, the resolution stack should be clean
+        container.register(SimpleService)
+        instance = container.get(SimpleService)
+        assert isinstance(instance, SimpleService)
+
+    def test_async_stack_not_leaked_on_circular_dependency(self) -> None:
+        """Test that the async resolution stack is not corrupted by circular dependency."""
+        container = Container()
+        container.register(_CircA)
+        container.register(_CircB)
+
+        async def run() -> SimpleService:
+            with pytest.raises(CircularDependencyError):
+                await container.get_async(_CircA)
+
+            container.register(SimpleService)
+            return await container.get_async(SimpleService)
+
+        instance = asyncio.run(run())
+        assert isinstance(instance, SimpleService)


### PR DESCRIPTION
## Summary

- **Centralize resolution loop**: Extract the duplicated dependency resolution loop from 8 sync/async methods into `_resolve_deps` / `_resolve_deps_async` on Container, plus `_injectable_to_param_deps` for Injectable field metadata conversion
- **Async Factory/Lazy support (#48)**: Add `async_resolver` parameter and `acall()` method to `Factory[T]` and `Lazy[T]`; async resolution paths now use `_make_wrapper_async` which provides both sync and async resolvers
- **Fix stack leak (#45)**: `get()` / `get_async()` no longer append to `_resolution_stack` before raising `CircularDependencyError`, preventing stale entries from corrupting subsequent resolutions

Fixes #45, fixes #48

## Test plan

- [x] All 414 existing tests pass (regression)
- [x] `mypy inversipy/` — no errors
- [x] `ruff check inversipy/` — no errors
- [x] New tests: `TestFactoryAcall` (3 tests), `TestLazyAcall` (3 tests), `TestCircularDependencyStackCleanup` (2 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)