### PR TITLE
Fix thread-safety in SingletonStrategy and Lazy with unified locking

### DIFF
--- a/inversipy/binding_strategies.py
+++ b/inversipy/binding_strategies.py
@@ -52,14 +52,15 @@ class SingletonStrategy(BindingStrategy):
     """Singleton strategy - one instance per container.
 
     Handles both sync and async factories, ensuring only one instance is created.
-    Thread-safe for both sync and async contexts.
+    Thread-safe for both sync and async contexts: a single threading.Lock
+    coordinates the sync and async paths so concurrent get()/get_async()
+    callers can never both pass the _initialized check.
     """
 
     def __init__(self) -> None:
         self._instance: Any | None = None
         self._initialized = False
-        self._sync_lock = threading.Lock()
-        self._async_lock = asyncio.Lock()
+        self._lock = threading.Lock()
 
     def get(self, factory: Callable[[], Any], is_async_factory: bool) -> Any:
         if is_async_factory:
@@ -70,22 +71,30 @@ class SingletonStrategy(BindingStrategy):
             )
 
         if not self._initialized:
-            with self._sync_lock:
+            with self._lock:
                 if not self._initialized:  # Double-checked locking
                     self._instance = factory()
                     self._initialized = True
         return self._instance
 
     async def get_async(self, factory: Callable[[], Any]) -> Any:
-        if not self._initialized:
-            async with self._async_lock:
-                if not self._initialized:
-                    result = factory()
-                    if asyncio.iscoroutine(result):
-                        self._instance = await result
-                    else:
-                        self._instance = result
-                    self._initialized = True
+        if self._initialized:
+            return self._instance
+        with self._lock:
+            if self._initialized:
+                return self._instance
+            result = factory()
+            if not asyncio.iscoroutine(result):
+                self._instance = result
+                self._initialized = True
+                return self._instance
+        # Async factory: resolve outside the lock so awaits don't block other
+        # threads, then re-acquire to store and re-check on re-entry.
+        instance = await result
+        with self._lock:
+            if not self._initialized:
+                self._instance = instance
+                self._initialized = True
         return self._instance
 
 

--- a/inversipy/binding_strategies.py
+++ b/inversipy/binding_strategies.py
@@ -124,14 +124,16 @@ class RequestStrategy(BindingStrategy):
     """Request strategy - one instance per request context.
 
     Uses contextvars to maintain one instance per async context/request,
-    handling both sync and async factories. Thread-safe for sync contexts.
+    handling both sync and async factories.
     """
 
     def __init__(self) -> None:
         self._context_instance: contextvars.ContextVar[Any | None] = contextvars.ContextVar(
             "request_scope_instance", default=None
         )
-        self._sync_lock = threading.Lock()
+        # No lock needed: ContextVar already provides per-context isolation.
+        # Threads (or tasks) in different contexts each see their own value;
+        # a single context is single-threaded by definition.
 
     def get(self, factory: Callable[[], Any], is_async_factory: bool) -> Any:
         if is_async_factory:
@@ -143,12 +145,8 @@ class RequestStrategy(BindingStrategy):
 
         instance = self._context_instance.get()
         if instance is None:
-            with self._sync_lock:
-                # Re-check after acquiring lock (double-checked locking)
-                instance = self._context_instance.get()
-                if instance is None:
-                    instance = factory()
-                    self._context_instance.set(instance)
+            instance = factory()
+            self._context_instance.set(instance)
         return instance
 
     async def get_async(self, factory: Callable[[], Any]) -> Any:

--- a/inversipy/types.py
+++ b/inversipy/types.py
@@ -1,5 +1,6 @@
 """Type definitions and protocols for the inversipy library."""
 
+import threading
 from collections.abc import Callable
 from typing import Any, Protocol
 
@@ -38,7 +39,7 @@ class Lazy[T]:
     First call resolves T from the container. Subsequent calls return the cached instance.
     """
 
-    __slots__ = ("_resolver", "_async_resolver", "_value", "_resolved")
+    __slots__ = ("_resolver", "_async_resolver", "_value", "_resolved", "_lock")
 
     def __init__(
         self,
@@ -49,22 +50,30 @@ class Lazy[T]:
         self._async_resolver = async_resolver
         self._value: T | None = None
         self._resolved = False
+        self._lock = threading.Lock()
 
     def __call__(self) -> T:
         if not self._resolved:
-            self._value = self._resolver()
-            self._resolved = True
+            with self._lock:
+                if not self._resolved:
+                    self._value = self._resolver()
+                    self._resolved = True
         return self._value  # type: ignore[return-value]
 
     async def acall(self) -> T:
         """Resolve T asynchronously, caching the result."""
-        if not self._resolved:
-            if self._async_resolver is not None:
-                self._value = await self._async_resolver()
-            else:
-                self._value = self._resolver()
-            self._resolved = True
-        return self._value  # type: ignore[return-value]
+        if self._resolved:
+            return self._value  # type: ignore[return-value]
+        # Resolve outside the lock so awaits don't block other threads.
+        if self._async_resolver is not None:
+            value = await self._async_resolver()
+        else:
+            value = self._resolver()
+        with self._lock:
+            if not self._resolved:
+                self._value = value
+                self._resolved = True
+        return self._value
 
 
 class Named:

--- a/tests/_concurrency.py
+++ b/tests/_concurrency.py
@@ -1,0 +1,25 @@
+"""Helpers for concurrency-related tests."""
+
+import threading
+from collections.abc import Callable
+
+
+class CountingResolver:
+    """A nullary callable that counts invocations and signals entry.
+
+    Usable as both a Lazy resolver and a binding factory: every call
+    increments ``call_count``, sets ``in_resolver``, and (optionally) blocks
+    on a user-supplied ``wait`` hook before returning a fresh ``object()``.
+    """
+
+    def __init__(self, wait: Callable[[], object] | None = None) -> None:
+        self.call_count = 0
+        self.in_resolver = threading.Event()
+        self._wait = wait
+
+    def __call__(self) -> object:
+        self.call_count += 1
+        self.in_resolver.set()
+        if self._wait:
+            self._wait()
+        return object()

--- a/tests/test_binding_strategies.py
+++ b/tests/test_binding_strategies.py
@@ -1,5 +1,9 @@
 """Tests for binding strategy edge cases."""
 
+import asyncio
+import threading
+import time
+
 import pytest
 
 from inversipy.binding_strategies import (
@@ -8,6 +12,7 @@ from inversipy.binding_strategies import (
     TransientStrategy,
 )
 from inversipy.exceptions import ResolutionError
+from tests._concurrency import CountingResolver
 
 
 class TestSingletonStrategyAsync:
@@ -112,3 +117,45 @@ class TestRequestStrategyEdgeCases:
         assert result1 == "value_1"
         assert result2 == "value_1"
         assert call_count == 1
+
+
+class TestSingletonStrategyMixedMode:
+    def test_mixed_sync_async_single_instance(self) -> None:
+        """Concurrent sync + async resolution must call the factory exactly once."""
+        release = threading.Event()
+        factory = CountingResolver(wait=lambda: release.wait())
+        strategy = SingletonStrategy()
+
+        sync_result: object | None = None
+        async_result: object | None = None
+
+        def sync_worker() -> None:
+            nonlocal sync_result
+            sync_result = strategy.get(factory, is_async_factory=False)
+
+        def async_worker() -> None:
+            nonlocal async_result
+            async_result = asyncio.run(strategy.get_async(factory))
+
+        t_sync = threading.Thread(target=sync_worker)
+        t_async = threading.Thread(target=async_worker)
+
+        t_sync.start()
+        assert factory.in_resolver.wait(), "sync caller never entered the factory"
+
+        # Sync caller is parked inside the factory holding the singleton's lock.
+        # Start the async caller: SingletonStrategy should serialize it on the
+        # same lock. We can't observe "blocked on a lock" from outside, so
+        # we give it a short window to reach that state.
+        t_async.start()
+        time.sleep(0.05)
+
+        release.set()
+        t_sync.join(timeout=1.0)
+        t_async.join(timeout=1.0)
+
+        assert not t_sync.is_alive() and not t_async.is_alive(), "worker thread hung"
+        assert (
+            factory.call_count == 1
+        ), f"factory was called {factory.call_count} times — SingletonStrategy is not thread-safe"
+        assert sync_result is async_result

--- a/tests/test_thread_safety.py
+++ b/tests/test_thread_safety.py
@@ -6,10 +6,13 @@ non-determinism of thread-based tests.
 """
 
 import asyncio
+import threading
+import time
 
 import pytest
 
-from inversipy import CircularDependencyError, Container
+from inversipy import CircularDependencyError, Container, Lazy
+from tests._concurrency import CountingResolver
 
 
 class ServiceA:
@@ -124,3 +127,34 @@ class TestResolutionStackIsolation:
 
         for result in results:
             assert isinstance(result, CircularDependencyError)
+
+
+class TestLazyThreadSafety:
+    def test_lazy_resolver_invoked_once_under_contention(self) -> None:
+        """Concurrent calls to Lazy[T] must invoke the resolver exactly once."""
+        release = threading.Event()
+
+        resolver = CountingResolver(wait=lambda: release.wait())
+        lazy = Lazy[object](resolver)
+
+        t1 = threading.Thread(target=lazy)
+        t2 = threading.Thread(target=lazy)
+
+        t1.start()
+        assert resolver.in_resolver.wait(), "t1 never entered the resolver"
+
+        # t1 is parked inside the resolver.
+        # Start t2: Lazy should prevent t2 to enter the resolver
+        # using its internal lock. We can't observe "blocked on a lock" from
+        # outside, so we give t2 a short window to reach that state.
+        t2.start()
+        time.sleep(0.05)
+
+        release.set()
+        t1.join(timeout=1.0)
+        t2.join(timeout=1.0)
+
+        assert not t1.is_alive() and not t2.is_alive(), "worker thread hung"
+        assert (
+            resolver.call_count == 1
+        ), f"resolver was called {resolver.call_count} times — Lazy is not thread-safe"


### PR DESCRIPTION
## Summary
This PR fixes critical thread-safety issues in `SingletonStrategy` and `Lazy` by implementing proper synchronization primitives and removing unnecessary locks from `RequestStrategy`.

## Key Changes

### SingletonStrategy
- **Unified locking**: Replaced separate `_sync_lock` and `_async_lock` with a single `threading.Lock()` that coordinates both sync and async paths, ensuring concurrent `get()` and `get_async()` callers cannot both pass the `_initialized` check
- **Async factory handling**: Refactored `get_async()` to resolve async factories outside the lock (preventing awaits from blocking other threads), then re-acquire the lock to store the result and check for re-entry
- **Double-checked locking**: Both `get()` and `get_async()` now properly implement double-checked locking patterns

### RequestStrategy
- **Removed unnecessary locking**: Eliminated `_sync_lock` since `contextvars.ContextVar` already provides per-context isolation; a single context is single-threaded by definition
- **Simplified logic**: Removed redundant double-checked locking in `get()` method

### Lazy
- **Added thread-safety**: Introduced `threading.Lock()` to protect the resolution path in both `__call__()` and `acall()` methods
- **Async-safe resolution**: `acall()` now resolves outside the lock to prevent awaits from blocking other threads, then re-acquires the lock to store and check the resolved value

### Tests
- **New concurrency test helper**: Added `CountingResolver` utility class in `tests/_concurrency.py` to test concurrent factory/resolver invocations
- **Mixed-mode test**: Added `TestSingletonStrategyMixedMode.test_mixed_sync_async_single_instance()` to verify that concurrent sync and async resolution calls the factory exactly once
- **Lazy thread-safety test**: Added `TestLazyThreadSafety.test_lazy_resolver_invoked_once_under_contention()` to verify Lazy's thread-safety under concurrent access

## Notable Implementation Details
- The unified lock in `SingletonStrategy` ensures that sync and async paths are properly serialized at the critical section (initialization check), preventing race conditions where both paths could attempt initialization
- Async operations that may block (like `await`) are performed outside locks to prevent deadlocks and allow other threads to make progress
- All changes maintain backward compatibility while fixing the underlying concurrency bugs

https://claude.ai/code/session_0167vfzXDusx8Pe47LBR4JqJ