### PR TITLE
Unify factory and class instantiation; improve cycle detection

### DIFF
--- a/inversipy/container.py
+++ b/inversipy/container.py
@@ -4,6 +4,7 @@ import asyncio
 import contextvars
 import inspect
 import types as types_mod
+from collections import deque
 from collections.abc import Callable
 from dataclasses import dataclass
 from functools import lru_cache
@@ -354,6 +355,20 @@ class Binding:
             sig = inspect.signature(factory)
             self._factory_has_params = len(sig.parameters) > 0
 
+        # Unified provider/invoke callables.
+        # _provider: what to introspect for dependency types (via analyze_parameters).
+        # _invoke: what to call with resolved kwargs to produce an instance.
+        # They differ for classes: _provider = cls.__init__ (for correct get_type_hints),
+        # _invoke = cls (calling cls(**kwargs) invokes __init__ via Python's protocol).
+        self._provider: Callable[..., Any] | None = None
+        self._invoke: Callable[..., Any] | None = None
+        if factory is not None:
+            self._provider = factory
+            self._invoke = factory
+        elif implementation is not None:
+            self._provider = implementation.__init__
+            self._invoke = implementation
+
         self._strategy = self._create_strategy(scope)
         self._lazy_strategy = self._create_strategy(scope)
 
@@ -405,77 +420,30 @@ class Binding:
         if self.instance is not None:
             return self.instance
 
-        if self.factory is not None:
-            if self._factory_has_params:
-                factory = self.factory
-
-                def factory_func() -> Any:
-                    return self._call_factory_with_deps(container, factory)
-
-            else:
-                factory_func = self.factory
-        elif self.implementation is not None:
-            implementation = self.implementation
+        if self.factory is not None and not self._factory_has_params:
+            factory_func = self.factory  # Parameterless fast-path
+        else:
+            binding = self
 
             def factory_func() -> Any:
-                return container._create_instance(implementation)
-
-        else:
-            raise ResolutionError(f"Cannot create instance for {self.key}")
+                return container._instantiate_binding(binding)
 
         return self._strategy.get(factory_func, self._is_async_factory)
-
-    def _call_factory_with_deps(self, container: "Container", factory: Callable[..., Any]) -> Any:
-        """Call a factory function, resolving its dependencies from the container."""
-        try:
-            deps = analyze_parameters(factory)
-            kwargs = container._resolve_deps(deps, f"factory for {self.key}")
-            return factory(**kwargs)
-        except Exception as e:
-            if isinstance(e, (ResolutionError, DependencyNotFoundError, CircularDependencyError)):
-                raise
-            raise ResolutionError(f"Failed to call factory for {self.key}: {e}")
 
     async def create_instance_async(self, container: "Container") -> Any:
         """Create an instance of the dependency (async context)."""
         if self.instance is not None:
             return self.instance
 
-        if self.factory is not None:
-            if self._factory_has_params:
-                factory = self.factory
-
-                async def factory_func() -> Any:
-                    return await self._call_factory_with_deps_async(container, factory)
-
-            else:
-                factory_func = self.factory
-        elif self.implementation is not None:
-            implementation = self.implementation
+        if self.factory is not None and not self._factory_has_params:
+            factory_func = self.factory  # Parameterless fast-path
+        else:
+            binding = self
 
             async def factory_func() -> Any:
-                return await container._create_instance_async(implementation)
-
-        else:
-            raise ResolutionError(f"Cannot create instance for {self.key}")
+                return await container._instantiate_binding_async(binding)
 
         return await self._strategy.get_async(factory_func)
-
-    async def _call_factory_with_deps_async(
-        self, container: "Container", factory: Callable[..., Any]
-    ) -> Any:
-        """Call a factory function asynchronously, resolving dependencies."""
-        try:
-            deps = analyze_parameters(factory)
-            kwargs = await container._resolve_deps_async(deps, f"factory for {self.key}")
-            result = factory(**kwargs)
-            if asyncio.iscoroutine(result):
-                return await result
-            return result
-        except Exception as e:
-            if isinstance(e, (ResolutionError, DependencyNotFoundError, CircularDependencyError)):
-                raise
-            raise ResolutionError(f"Failed to call factory for {self.key}: {e}")
 
 
 class Container:
@@ -942,127 +910,172 @@ class Container:
         target = f"class '{cls.__name__}'"
         return await self._resolve_deps_async(deps, target), {}
 
-    def _create_instance[T](self, cls: type[T]) -> T:
-        """Create an instance of a class, resolving its dependencies."""
-        try:
-            injectable_result = self._resolve_injectable_deps(cls)
-            if injectable_result is not None:
-                injectable_kwargs, _ = injectable_result
-                return cls(**injectable_kwargs)
+    def _instantiate_binding(self, binding: "Binding") -> Any:
+        """Create an instance from a binding, resolving its dependencies.
 
-            deps = analyze_parameters(cls.__init__, skip_self=True)
-            target = f"class '{cls.__name__}'"
+        Handles both factory-based and implementation-based bindings uniformly
+        via binding._provider (what to introspect) and binding._invoke (what to
+        call with resolved kwargs).
+        """
+        try:
+            # @Injectable fast-path (class-only decorator metadata)
+            if binding.implementation is not None:
+                injectable_result = self._resolve_injectable_deps(binding.implementation)
+                if injectable_result is not None:
+                    injectable_kwargs, _ = injectable_result
+                    return binding.implementation(**injectable_kwargs)
+
+            # Generic path: analyze _provider, resolve deps, invoke.
+            # _provider and _invoke are guaranteed non-None for non-instance
+            # bindings (set in Binding.__init__); instance bindings exit via
+            # the early return in create_instance/create_instance_async.
+            assert binding._provider is not None
+            assert binding._invoke is not None
+            deps = analyze_parameters(binding._provider, skip_self=True)
+            target = (
+                f"class '{binding.implementation.__name__}'"
+                if binding.implementation is not None
+                else f"factory for {binding.key}"
+            )
             kwargs = self._resolve_deps(deps, target)
-            return cls(**kwargs)
+            return binding._invoke(**kwargs)
         except Exception as e:
             if isinstance(e, (ResolutionError, DependencyNotFoundError, CircularDependencyError)):
                 raise
-            raise ResolutionError(f"Failed to create instance of {cls.__name__}: {e}")
+            if binding.factory is not None:
+                raise ResolutionError(f"Failed to call factory for {binding.key}: {e}")
+            assert binding.implementation is not None
+            raise ResolutionError(
+                f"Failed to create instance of {binding.implementation.__name__}: {e}"
+            )
 
-    async def _create_instance_async[T](self, cls: type[T]) -> T:
-        """Create an instance of a class asynchronously, resolving its dependencies."""
+    async def _instantiate_binding_async(self, binding: "Binding") -> Any:
+        """Create an instance from a binding asynchronously, resolving deps."""
         try:
-            injectable_result = await self._resolve_injectable_deps_async(cls)
-            if injectable_result is not None:
-                injectable_kwargs, _ = injectable_result
-                return cls(**injectable_kwargs)
+            if binding.implementation is not None:
+                injectable_result = await self._resolve_injectable_deps_async(
+                    binding.implementation
+                )
+                if injectable_result is not None:
+                    injectable_kwargs, _ = injectable_result
+                    return binding.implementation(**injectable_kwargs)
 
-            deps = analyze_parameters(cls.__init__, skip_self=True)
-            target = f"class '{cls.__name__}'"
+            assert binding._provider is not None
+            assert binding._invoke is not None
+            deps = analyze_parameters(binding._provider, skip_self=True)
+            target = (
+                f"class '{binding.implementation.__name__}'"
+                if binding.implementation is not None
+                else f"factory for {binding.key}"
+            )
             kwargs = await self._resolve_deps_async(deps, target)
-            return cls(**kwargs)
+            result = binding._invoke(**kwargs)
+            if asyncio.iscoroutine(result):
+                return await result
+            return result
         except Exception as e:
             if isinstance(e, (ResolutionError, DependencyNotFoundError, CircularDependencyError)):
                 raise
-            raise ResolutionError(f"Failed to create instance of {cls.__name__}: {e}")
+            if binding.factory is not None:
+                raise ResolutionError(f"Failed to call factory for {binding.key}: {e}")
+            assert binding.implementation is not None
+            raise ResolutionError(
+                f"Failed to create instance of {binding.implementation.__name__}: {e}"
+            )
 
     def create_child(self, name: str | None = None) -> "Container":
         """Create a child container."""
         child_name = name if name else f"{self._name}.Child"
         return Container(parent=self, name=child_name)
 
-    def _get_implementation_dependencies(self, cls: type[Any]) -> list[type[Any]]:
-        """Get the dependency types required by a class implementation."""
-        dependencies: list[type[Any]] = []
-        try:
-            deps = analyze_parameters(cls.__init__, skip_self=True)
-            for dep in deps:
-                if dep.dep_type is not _MissingType and not dep.has_default:
-                    dependencies.append(dep.dep_type)
-        except Exception:
-            pass
-        return dependencies
-
     def _detect_cycles(self) -> list[list[type[Any]]]:
         """Detect circular dependencies in the container.
+
+        Uses multi-root DFS over all registered bindings. Dependencies are
+        extracted from each binding's ``_provider`` callable uniformly — no
+        distinction between factories and class implementations.
+
+        Lazy[T] and Factory[T] wrapper edges do not recurse in the current
+        traversal (they defer resolution at runtime) but are enqueued as
+        independent roots so that cycles *within* the deferred subgraph are
+        still detected.
 
         Note: This method accesses module._bindings via hasattr checks because
         cycle detection requires inspecting internal binding state. This is
         intentional duck-typing — only Container-based modules support validation.
         """
-        graph: dict[type[Any], list[type[Any]]] = {}
-
-        for key, bindings in self._bindings.items():
-            for binding in bindings:
-                if binding.instance is not None or binding.factory is not None:
-                    continue
-                if binding.implementation is not None:
-                    node_type = get_type_from_key(key)
-                    deps = self._get_implementation_dependencies(binding.implementation)
-                    registered_deps = [
-                        d
-                        for d in deps
-                        if d in self._bindings
-                        or any(d in m._bindings for m in self._modules if hasattr(m, "_bindings"))
-                    ]
-                    graph[node_type] = registered_deps
-
+        # Collect all binding sources into a unified lookup.
+        all_bindings: dict[DependencyKey, list[Binding]] = dict(self._bindings)
         for module in self._modules:
             if hasattr(module, "_bindings"):
                 for key, bindings in module._bindings.items():
-                    for binding in bindings:
-                        if binding.instance is not None or binding.factory is not None:
-                            continue
-                        if binding.implementation is not None:
-                            node_type = get_type_from_key(key)
-                            deps = self._get_implementation_dependencies(binding.implementation)
-                            registered_deps = [
-                                d
-                                for d in deps
-                                if d in self._bindings
-                                or d in module._bindings
-                                or any(
-                                    d in m._bindings
-                                    for m in self._modules
-                                    if hasattr(m, "_bindings")
-                                )
-                            ]
-                            graph[node_type] = registered_deps
+                    all_bindings.setdefault(key, []).extend(bindings)
 
-        cycles: list[list[type[Any]]] = []
-        visited: set[type[Any]] = set()
-        rec_stack: set[type[Any]] = set()
+        def _is_registered(dep_key: DependencyKey) -> bool:
+            return dep_key in all_bindings
+
+        # Seed all registered keys as roots.
+        roots: deque[DependencyKey] = deque(all_bindings.keys())
+        global_visited: set[DependencyKey] = set()
+        rec_stack: set[DependencyKey] = set()
         path: list[type[Any]] = []
+        cycles: list[list[type[Any]]] = []
 
-        def dfs(node: type[Any]) -> None:
-            visited.add(node)
-            rec_stack.add(node)
-            path.append(node)
+        def dfs(key: DependencyKey) -> None:
+            if key in global_visited:
+                return
+            if key in rec_stack:
+                node_type = get_type_from_key(key)
+                cycle_start = path.index(node_type)
+                cycles.append(path[cycle_start:] + [node_type])
+                return
 
-            for neighbor in graph.get(node, []):
-                if neighbor not in visited:
-                    dfs(neighbor)
-                elif neighbor in rec_stack:
-                    cycle_start = path.index(neighbor)
-                    cycle = path[cycle_start:] + [neighbor]
-                    cycles.append(cycle)
+            rec_stack.add(key)
+            path.append(get_type_from_key(key))
 
+            bindings = all_bindings.get(key, [])
+            for binding in bindings:
+                if binding._provider is None:
+                    continue  # Instance bindings have no deps
+
+                try:
+                    deps = analyze_parameters(binding._provider, skip_self=True)
+                except Exception:
+                    continue
+
+                for dep in deps:
+                    if dep.dep_type is _MissingType or dep.has_default:
+                        continue
+
+                    dep_key = make_key(dep.dep_type, dep.dep_name)
+
+                    if dep.wrapper_type in (Lazy, Factory):
+                        # Deferred resolution — don't recurse, schedule as new root
+                        if dep_key not in global_visited:
+                            roots.append(dep_key)
+                        continue
+
+                    if dep.is_optional and not _is_registered(dep_key):
+                        continue
+
+                    if dep.is_collection:
+                        # Fan out to all bindings matching this type
+                        for registered_key in all_bindings:
+                            if get_type_from_key(registered_key) == dep.dep_type:
+                                dfs(registered_key)
+                        continue
+
+                    if _is_registered(dep_key):
+                        dfs(dep_key)
+
+            rec_stack.remove(key)
             path.pop()
-            rec_stack.remove(node)
+            global_visited.add(key)
 
-        for node in graph:
-            if node not in visited:
-                dfs(node)
+        while roots:
+            root = roots.popleft()
+            if root not in global_visited:
+                dfs(root)
 
         return cycles
 

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -662,6 +662,49 @@ class TestBindingErrorPaths:
         with pytest.raises(ResolutionError, match="Failed to call factory"):
             container.get(DependentService)
 
+    def test_class_with_deps_raising_non_resolution_exception(self) -> None:
+        """Class __init__ raising ValueError should be wrapped in ResolutionError."""
+        container = Container()
+        container.register(SimpleService)
+
+        class BrokenInit:
+            def __init__(self, simple: SimpleService) -> None:
+                raise ValueError("init failed")
+
+        container.register(BrokenInit)
+
+        with pytest.raises(ResolutionError, match="Failed to create instance"):
+            container.get(BrokenInit)
+
+    @pytest.mark.asyncio
+    async def test_async_factory_raising_non_resolution_exception(self) -> None:
+        """Async: factory raising ValueError should be wrapped in ResolutionError."""
+        container = Container()
+        container.register(SimpleService)
+
+        def bad_factory(simple: SimpleService) -> DependentService:
+            raise ValueError("something went wrong")
+
+        container.register_factory(DependentService, bad_factory)
+
+        with pytest.raises(ResolutionError, match="Failed to call factory"):
+            await container.get_async(DependentService)
+
+    @pytest.mark.asyncio
+    async def test_async_class_raising_non_resolution_exception(self) -> None:
+        """Async: class __init__ raising ValueError should be wrapped in ResolutionError."""
+        container = Container()
+        container.register(SimpleService)
+
+        class BrokenInit:
+            def __init__(self, simple: SimpleService) -> None:
+                raise ValueError("init failed")
+
+        container.register(BrokenInit)
+
+        with pytest.raises(ResolutionError, match="Failed to create instance"):
+            await container.get_async(BrokenInit)
+
     @pytest.mark.asyncio
     async def test_async_create_instance_with_preexisting_instance(self) -> None:
         """Async create_instance should return pre-existing instance."""

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from inversipy import Container, ValidationError
+from inversipy import Container, Factory, Lazy, ValidationError
 
 
 class ServiceA:
@@ -192,6 +192,55 @@ class SelfDependent:
         self.self_ref = self_ref
 
 
+class LazyConsumerA:
+    """Service that lazily depends on LazyDepB."""
+
+    def __init__(self, b: Lazy["LazyDepB"]) -> None:
+        self.b = b
+
+
+class LazyDepB:
+    """Service that depends on LazyConsumerA."""
+
+    def __init__(self, a: LazyConsumerA) -> None:
+        self.a = a
+
+
+class LazyRootA:
+    """Service that lazily depends on InternalCycleB."""
+
+    def __init__(self, b: Lazy["InternalCycleB"]) -> None:
+        self.b = b
+
+
+class InternalCycleB:
+    """Service in B <-> C cycle, reachable via Lazy from LazyRootA."""
+
+    def __init__(self, c: "InternalCycleC") -> None:
+        self.c = c
+
+
+class InternalCycleC:
+    """Service in B <-> C cycle."""
+
+    def __init__(self, b: InternalCycleB) -> None:
+        self.b = b
+
+
+class FactoryConsumerA:
+    """Service that depends on FactoryDepB via Factory wrapper."""
+
+    def __init__(self, b: Factory["FactoryDepB"]) -> None:
+        self.b = b
+
+
+class FactoryDepB:
+    """Service that depends on FactoryConsumerA."""
+
+    def __init__(self, a: FactoryConsumerA) -> None:
+        self.a = a
+
+
 class TestCycleDetectionInValidation:
     """Test that validation detects circular dependencies."""
 
@@ -250,15 +299,139 @@ class TestCycleDetectionInValidation:
         # Should not raise
         container.validate()
 
-    def test_validation_cycle_detection_ignores_factories(self) -> None:
-        """Test that cycle detection skips factory registrations."""
+    def test_validation_skips_factories_without_type_hints(self) -> None:
+        """Factories with untyped parameters produce no cycle-detection edges."""
         container = Container()
-        # Factories can handle circular deps manually, so we don't validate them
+        # Untyped lambdas: analyze_parameters() cannot resolve their deps,
+        # so no graph edges are produced — no cycle is reported.
         container.register_factory(CircularA, lambda b: CircularA(b))
         container.register_factory(CircularB, lambda a: CircularB(a))
 
-        # Should not raise - factories are skipped
-        container.validate()
+        container.validate()  # Should not raise
+
+    def test_validation_detects_typed_factory_cycle(self) -> None:
+        """Two typed factories forming A <-> B cycle should be detected."""
+        container = Container()
+
+        def make_a(b: CircularB) -> CircularA:
+            return CircularA(b)
+
+        def make_b(a: CircularA) -> CircularB:
+            return CircularB(a)
+
+        container.register_factory(CircularA, make_a)
+        container.register_factory(CircularB, make_b)
+
+        with pytest.raises(ValidationError) as exc_info:
+            container.validate()
+
+        error_msg = str(exc_info.value)
+        assert "Circular dependency detected" in error_msg
+        assert "CircularA" in error_msg
+        assert "CircularB" in error_msg
+
+    def test_validation_detects_longer_typed_factory_cycle(self) -> None:
+        """Three typed factories forming C -> D -> E -> C should be detected."""
+        container = Container()
+
+        def make_c(d: CircularD) -> CircularC:
+            return CircularC(d)
+
+        def make_d(e: CircularE) -> CircularD:
+            return CircularD(e)
+
+        def make_e(c: CircularC) -> CircularE:
+            return CircularE(c)
+
+        container.register_factory(CircularC, make_c)
+        container.register_factory(CircularD, make_d)
+        container.register_factory(CircularE, make_e)
+
+        with pytest.raises(ValidationError) as exc_info:
+            container.validate()
+
+        error_msg = str(exc_info.value)
+        assert "Circular dependency detected" in error_msg
+        assert "CircularC" in error_msg
+        assert "CircularD" in error_msg
+        assert "CircularE" in error_msg
+
+    def test_validation_detects_self_referential_typed_factory(self) -> None:
+        """A factory whose typed param is its own return type should be detected."""
+        container = Container()
+
+        def make_self(s: SelfDependent) -> SelfDependent:
+            return SelfDependent(s)
+
+        container.register_factory(SelfDependent, make_self)
+
+        with pytest.raises(ValidationError) as exc_info:
+            container.validate()
+
+        error_msg = str(exc_info.value)
+        assert "Circular dependency detected" in error_msg
+        assert "SelfDependent" in error_msg
+
+    def test_validation_detects_mixed_factory_and_class_cycle(self) -> None:
+        """A cycle spanning a class registration and a typed factory should be detected."""
+        container = Container()
+
+        def make_b(a: CircularA) -> CircularB:
+            return CircularB(a)
+
+        container.register(CircularA)  # class: depends on CircularB
+        container.register_factory(CircularB, make_b)  # factory: depends on CircularA
+
+        with pytest.raises(ValidationError) as exc_info:
+            container.validate()
+
+        error_msg = str(exc_info.value)
+        assert "Circular dependency detected" in error_msg
+        assert "CircularA" in error_msg
+        assert "CircularB" in error_msg
+
+    def test_validation_passes_for_typed_factory_without_cycle(self) -> None:
+        """A typed factory with non-cyclic deps should pass validation."""
+        container = Container()
+
+        def make_c(a: ServiceA) -> ServiceC:
+            return ServiceC(ServiceB(a))
+
+        container.register(ServiceA)
+        container.register_factory(ServiceC, make_c)
+
+        container.validate()  # Should not raise
+
+    def test_validation_lazy_breaks_direct_cycle(self) -> None:
+        """Lazy[T] breaks a direct cycle: A(b: Lazy[B]) + B(a: A) is not circular."""
+        container = Container()
+        container.register(LazyConsumerA)
+        container.register(LazyDepB)
+
+        container.validate()  # Should not raise — Lazy breaks the cycle
+
+    def test_validation_lazy_does_not_hide_internal_cycle(self) -> None:
+        """Lazy breaks the outer edge but internal subgraph cycles are still caught."""
+        container = Container()
+        container.register(LazyRootA)
+        container.register(InternalCycleB)
+        container.register(InternalCycleC)
+
+        with pytest.raises(ValidationError) as exc_info:
+            container.validate()
+
+        error_msg = str(exc_info.value)
+        assert "Circular dependency detected" in error_msg
+        assert "InternalCycleB" in error_msg
+        assert "InternalCycleC" in error_msg
+
+    def test_validation_factory_wrapper_breaks_cycle(self) -> None:
+        """Factory[T] breaks a direct cycle the same way Lazy[T] does."""
+        container = Container()
+        container.register(FactoryConsumerA)
+        container.register(FactoryDepB)
+
+        container.validate()  # Should not raise — Factory breaks the cycle
 
     def test_validation_cycle_detection_ignores_instances(self) -> None:
         """Test that cycle detection skips instance registrations."""

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -437,16 +437,19 @@ class TestCycleDetectionInValidation:
         """Optional deps that are not registered don't produce cycle-detection edges."""
 
         class OptionalConsumer:
-            def __init__(self, a: ServiceA, b: ServiceB | None = None) -> None:
+            def __init__(self, a: ServiceA, b: ServiceB | None) -> None:
                 self.a = a
                 self.b = b
 
         container = Container()
         container.register(ServiceA)
         container.register(OptionalConsumer)
-        # ServiceB is NOT registered — optional dep should be silently skipped
-
-        container.validate()  # Should not raise
+        # ServiceB is NOT registered — cycle detection should skip the optional dep
+        # rather than following it into unresolvable territory.
+        # (We call _detect_cycles directly because validate() has a separate
+        # per-dep check that flags unregistered deps independently of cycles.)
+        cycles = container._detect_cycles()
+        assert len(cycles) == 0
 
     def test_validation_collection_dep_does_not_introduce_false_cycle(self) -> None:
         """InjectAll deps fan out to all matching bindings without false cycles."""

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from inversipy import Container, Factory, Lazy, ValidationError
+from inversipy import Container, Factory, InjectAll, Lazy, ValidationError
 
 
 class ServiceA:
@@ -432,6 +432,34 @@ class TestCycleDetectionInValidation:
         container.register(FactoryDepB)
 
         container.validate()  # Should not raise — Factory breaks the cycle
+
+    def test_validation_optional_dep_skipped_when_missing(self) -> None:
+        """Optional deps that are not registered don't produce cycle-detection edges."""
+
+        class OptionalConsumer:
+            def __init__(self, a: ServiceA, b: ServiceB | None = None) -> None:
+                self.a = a
+                self.b = b
+
+        container = Container()
+        container.register(ServiceA)
+        container.register(OptionalConsumer)
+        # ServiceB is NOT registered — optional dep should be silently skipped
+
+        container.validate()  # Should not raise
+
+    def test_validation_collection_dep_does_not_introduce_false_cycle(self) -> None:
+        """InjectAll deps fan out to all matching bindings without false cycles."""
+
+        class PluginConsumer:
+            def __init__(self, plugins: InjectAll[ServiceA]) -> None:
+                self.plugins = plugins
+
+        container = Container()
+        container.register(ServiceA)
+        container.register(PluginConsumer)
+
+        container.validate()  # Should not raise
 
     def test_validation_cycle_detection_ignores_instances(self) -> None:
         """Test that cycle detection skips instance registrations."""


### PR DESCRIPTION
## Summary

This PR refactors the dependency instantiation logic to treat factories and class implementations uniformly, and significantly improves circular dependency detection to handle typed factories and wrapper types (Lazy, Factory).

## Key Changes

- **Unified instantiation path**: Introduced `_provider` and `_invoke` attributes on `Binding` to separate introspection (what to analyze for dependencies) from invocation (what to call with resolved kwargs). For classes, `_provider = cls.__init__` (for correct type hints) while `_invoke = cls` (to invoke via Python's calling protocol). Factories use the same callable for both.

- **Simplified `create_instance` and `create_instance_async`**: Removed separate code paths for factories vs. implementations. Both now delegate to unified `_instantiate_binding` and `_instantiate_binding_async` methods, reducing duplication and improving maintainability.

- **Enhanced cycle detection**: Completely rewrote `_detect_cycles()` to:
  - Use multi-root DFS over all registered bindings (not just class implementations)
  - Analyze both typed factories and class constructors uniformly via `binding._provider`
  - Properly handle `Lazy[T]` and `Factory[T]` wrappers by treating them as deferred roots rather than blocking edges
  - Detect cycles within deferred subgraphs (e.g., a cycle hidden behind a Lazy wrapper)
  - Support collection dependencies and optional parameters

- **Removed obsolete methods**: Deleted `_get_implementation_dependencies`, `_call_factory_with_deps`, and `_call_factory_with_deps_async` in favor of the unified approach.

## Notable Implementation Details

- The cycle detection algorithm now uses a deque to manage multiple independent roots, allowing it to detect cycles in both the main dependency graph and within deferred subgraphs (Lazy/Factory).
- Wrapper types (Lazy, Factory) are enqueued as new roots for traversal but do not cause recursion on the outer edge, effectively "breaking" direct cycles while still catching internal cycles.
- All cycle detection logic now operates on `DependencyKey` (which includes both type and optional name) rather than just types, improving accuracy for named dependencies.
- Comprehensive test coverage added for typed factories, mixed factory/class cycles, and wrapper-based cycle breaking.

https://claude.ai/code/session_01AHKhtj9BFZtQ7FfxzikidG