### PR TITLE
fix(container): raise AmbiguousDependencyError eagerly in Lazy[T]

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,6 +95,22 @@ This makes it easier to:
 - Revert specific changes if needed
 - Understand the history of the codebase
 
+## Bug Fixes: TDD Style
+
+When fixing bugs, follow a **Test-Driven Development** workflow:
+
+1. **Write a failing test first** — Create a test that reproduces the bug and confirms it fails
+2. **Run the test** — Verify it fails for the expected reason
+3. **Implement the fix** — Make the minimal code change to fix the bug
+4. **Run the test again** — Verify it now passes
+5. **Run the full test suite** — Ensure no regressions
+
+### Rationale:
+
+- The failing test proves the bug exists and is reproducible
+- The fix is validated against a concrete test case
+- Prevents regressions by keeping the test in the suite
+
 ## Design Philosophy
 
 The type system serves as the configuration language for dependency injection. Classes declare dependencies through Python type annotations and remain completely unaware of the DI container — they are plain objects usable without the framework. Around this foundation, the library layers real encapsulation (private-by-default module bindings), pluggable lifecycle management (scopes as interchangeable strategies rather than a fixed hierarchy), and layered safety guarantees (static and runtime circular dependency detection, container freezing, and typed exceptions) — all while maintaining dual sync/async support. The result is a framework that combines zero-configuration autowiring with the structural guardrails needed for complex applications, without ever coupling application code to the container.

--- a/inversipy/container.py
+++ b/inversipy/container.py
@@ -952,7 +952,10 @@ class Container:
             kwargs = self._resolve_deps(deps, target)
             return binding._invoke(**kwargs)
         except Exception as e:
-            if isinstance(e, (ResolutionError, DependencyNotFoundError, CircularDependencyError, AmbiguousDependencyError)):
+            if isinstance(e, (
+                ResolutionError, DependencyNotFoundError,
+                CircularDependencyError, AmbiguousDependencyError,
+            )):
                 raise
             if binding.factory is not None:
                 raise ResolutionError(f"Failed to call factory for {binding.key}: {e}")
@@ -986,7 +989,10 @@ class Container:
                 return await result
             return result
         except Exception as e:
-            if isinstance(e, (ResolutionError, DependencyNotFoundError, CircularDependencyError, AmbiguousDependencyError)):
+            if isinstance(e, (
+                ResolutionError, DependencyNotFoundError,
+                CircularDependencyError, AmbiguousDependencyError,
+            )):
                 raise
             if binding.factory is not None:
                 raise ResolutionError(f"Failed to call factory for {binding.key}: {e}")

--- a/inversipy/container.py
+++ b/inversipy/container.py
@@ -952,10 +952,15 @@ class Container:
             kwargs = self._resolve_deps(deps, target)
             return binding._invoke(**kwargs)
         except Exception as e:
-            if isinstance(e, (
-                ResolutionError, DependencyNotFoundError,
-                CircularDependencyError, AmbiguousDependencyError,
-            )):
+            if isinstance(
+                e,
+                (
+                    ResolutionError,
+                    DependencyNotFoundError,
+                    CircularDependencyError,
+                    AmbiguousDependencyError,
+                ),
+            ):
                 raise
             if binding.factory is not None:
                 raise ResolutionError(f"Failed to call factory for {binding.key}: {e}")
@@ -989,10 +994,15 @@ class Container:
                 return await result
             return result
         except Exception as e:
-            if isinstance(e, (
-                ResolutionError, DependencyNotFoundError,
-                CircularDependencyError, AmbiguousDependencyError,
-            )):
+            if isinstance(
+                e,
+                (
+                    ResolutionError,
+                    DependencyNotFoundError,
+                    CircularDependencyError,
+                    AmbiguousDependencyError,
+                ),
+            ):
                 raise
             if binding.factory is not None:
                 raise ResolutionError(f"Failed to call factory for {binding.key}: {e}")

--- a/inversipy/container.py
+++ b/inversipy/container.py
@@ -94,6 +94,12 @@ def _make_wrapper(
     binding = container._find_binding(key)
     if binding is not None:
         return binding.create_lazy_wrapper(container, dep_type, dep_name)
+
+    # Raise eagerly if ambiguous, rather than deferring to Lazy call time
+    bindings = container._bindings.get(key, [])
+    if len(bindings) > 1:
+        raise AmbiguousDependencyError(dep_type, len(bindings), container._name)
+
     return Lazy(resolver)
 
 
@@ -115,6 +121,12 @@ def _make_wrapper_async(
     binding = container._find_binding(key)
     if binding is not None:
         return binding.create_lazy_wrapper_async(container, dep_type, dep_name)
+
+    # Raise eagerly if ambiguous, rather than deferring to Lazy call time
+    bindings = container._bindings.get(key, [])
+    if len(bindings) > 1:
+        raise AmbiguousDependencyError(dep_type, len(bindings), container._name)
+
     return Lazy(sync_resolver, async_resolver)
 
 
@@ -940,7 +952,7 @@ class Container:
             kwargs = self._resolve_deps(deps, target)
             return binding._invoke(**kwargs)
         except Exception as e:
-            if isinstance(e, (ResolutionError, DependencyNotFoundError, CircularDependencyError)):
+            if isinstance(e, (ResolutionError, DependencyNotFoundError, CircularDependencyError, AmbiguousDependencyError)):
                 raise
             if binding.factory is not None:
                 raise ResolutionError(f"Failed to call factory for {binding.key}: {e}")
@@ -974,7 +986,7 @@ class Container:
                 return await result
             return result
         except Exception as e:
-            if isinstance(e, (ResolutionError, DependencyNotFoundError, CircularDependencyError)):
+            if isinstance(e, (ResolutionError, DependencyNotFoundError, CircularDependencyError, AmbiguousDependencyError)):
                 raise
             if binding.factory is not None:
                 raise ResolutionError(f"Failed to call factory for {binding.key}: {e}")

--- a/tests/test_factory_lazy.py
+++ b/tests/test_factory_lazy.py
@@ -6,6 +6,7 @@ from abc import ABC, abstractmethod
 import pytest
 
 from inversipy import (
+    AmbiguousDependencyError,
     CircularDependencyError,
     Container,
     DependencyNotFoundError,
@@ -264,6 +265,60 @@ class TestLazy:
         dep = container.get(DependentWithLazy)
         with pytest.raises((DependencyNotFoundError, ResolutionError)):
             dep.lazy()
+
+    def test_lazy_ambiguous_bindings_raises_eagerly(self) -> None:
+        """Ambiguous bindings for Lazy[T] should raise at resolution time, not call time."""
+        container = Container()
+        container.register(IService, ServiceA)
+        container.register(IService, ServiceB)
+
+        class Consumer:
+            def __init__(self, service: Lazy[IService]) -> None:
+                self.service = service
+
+        container.register(Consumer)
+
+        with pytest.raises(AmbiguousDependencyError):
+            container.get(Consumer)
+
+    def test_async_lazy_ambiguous_bindings_raises_eagerly(self) -> None:
+        """Ambiguous bindings for Lazy[T] should raise at async resolution time."""
+        container = Container()
+        container.register(IService, ServiceA)
+        container.register(IService, ServiceB)
+
+        class Consumer:
+            def __init__(self, service: Lazy[IService]) -> None:
+                self.service = service
+
+        container.register(Consumer)
+
+        async def run() -> None:
+            await container.get_async(Consumer)
+
+        with pytest.raises(AmbiguousDependencyError):
+            asyncio.run(run())
+
+    def test_lazy_ambiguous_after_resolution_raises_at_call_time(self) -> None:
+        """If container becomes ambiguous after Lazy is created, error at call time."""
+        container = Container()
+        container.register(IService, ServiceA)
+
+        class Consumer:
+            def __init__(self, service: Lazy[IService]) -> None:
+                self.service = service
+
+        container.register(Consumer)
+
+        # Resolve with a single binding — Lazy wrapper is created successfully
+        consumer = container.get(Consumer)
+
+        # Now add a second binding, making it ambiguous
+        container.register(IService, ServiceB)
+
+        # The Lazy's resolver calls container.get(), which detects ambiguity
+        with pytest.raises(AmbiguousDependencyError):
+            consumer.service()
 
 
 class TestFactoryAcall:


### PR DESCRIPTION
## Summary

- Raise `AmbiguousDependencyError` eagerly in `_make_wrapper()` and `_make_wrapper_async()` when multiple unnamed bindings exist, instead of deferring the error to when `Lazy[T]` is called
- Add `AmbiguousDependencyError` to the re-raise list in `_instantiate_binding` and `_instantiate_binding_async` so the error propagates without being wrapped in `ResolutionError`
- Add TDD workflow guideline to CLAUDE.md

## Test plan

- [x] `test_lazy_ambiguous_bindings_raises_eagerly` — verifies sync resolution raises eagerly
- [x] `test_async_lazy_ambiguous_bindings_raises_eagerly` — verifies async resolution raises eagerly
- [x] `test_lazy_ambiguous_after_resolution_raises_at_call_time` — verifies deferred ambiguity (container modified after Lazy created) still raises at call time
- [x] Full test suite passes (444 tests)

Closes #47

https://claude.ai/code/session_01W2t7nQJW3YhV6TnYbkY3AZ