### PR TITLE
fix(types): make Named immutable to prevent dict/set corruption

### DIFF
--- a/inversipy/types.py
+++ b/inversipy/types.py
@@ -2,6 +2,7 @@
 
 import threading
 from collections.abc import Callable
+from dataclasses import dataclass
 from typing import Any, Protocol
 
 type FactoryCallable[T] = Callable[..., T]
@@ -76,6 +77,7 @@ class Lazy[T]:
         return self._value
 
 
+@dataclass(frozen=True, slots=True, eq=False)
 class Named:
     """Qualifier for named dependency injection.
 
@@ -94,24 +96,13 @@ class Named:
         replica = container.get(IDatabase, name="replica")
     """
 
-    __slots__ = ("name",)
-    __match_args__ = ("name",)
+    name: str
 
-    def __init__(self, name: str) -> None:
-        """Initialize a Named qualifier.
-
-        Args:
-            name: The qualifier name for this dependency
-
-        Raises:
-            TypeError: If name is not a string
-            ValueError: If name is empty or whitespace-only
-        """
-        if not isinstance(name, str):
-            raise TypeError(f"Named qualifier must be a string, got {type(name).__name__}")
-        if not name or not name.strip():
+    def __post_init__(self) -> None:
+        if not isinstance(self.name, str):
+            raise TypeError(f"Named qualifier must be a string, got {type(self.name).__name__}")
+        if not self.name or not self.name.strip():
             raise ValueError("Named qualifier cannot be empty or whitespace-only")
-        self.name = name
 
     def __repr__(self) -> str:
         return f'Named("{self.name}")'

--- a/tests/test_named_bindings.py
+++ b/tests/test_named_bindings.py
@@ -559,6 +559,27 @@ class TestNamedMarkerClass:
         with pytest.raises(TypeError, match="must be a string"):
             Named(123)  # type: ignore[arg-type]
 
+    def test_named_is_immutable(self) -> None:
+        """Test that Named instances cannot be mutated after creation."""
+        n = Named("primary")
+        with pytest.raises(AttributeError):
+            n.name = "changed"  # type: ignore[misc]
+
+    def test_named_hash_stability_after_mutation_attempt(self) -> None:
+        """Test that hash remains stable (mutation is blocked, hash doesn't change)."""
+        n = Named("primary")
+        original_hash = hash(n)
+        with pytest.raises(AttributeError):
+            n.name = "changed"  # type: ignore[misc]
+        assert hash(n) == original_hash
+        assert hash(n) == hash(("Named", "primary"))
+
+    def test_named_delete_blocked(self) -> None:
+        """Test that deleting name attribute is blocked."""
+        n = Named("primary")
+        with pytest.raises(AttributeError):
+            del n.name  # type: ignore[misc]
+
 
 class TestNamedBindingsErrorMessages:
     """Test error messages include name information."""


### PR DESCRIPTION
## Summary

- Convert `Named` from a manual `__slots__` class to a `@dataclass(frozen=True, slots=True, eq=False)`, preventing mutation of the `name` attribute after construction
- Add tests verifying immutability (assignment blocked, deletion blocked, hash stability)
- Fixes a bug where reassigning `name` after using a `Named` instance as a dict key or set member would silently corrupt lookups

Closes #49

## Test plan

- [x] New `test_named_is_immutable` passes — `AttributeError` raised on assignment
- [x] New `test_named_hash_stability_after_mutation_attempt` passes — hash unchanged
- [x] New `test_named_delete_blocked` passes — `AttributeError` raised on deletion
- [x] All 6 existing `TestNamedMarkerClass` tests pass (equality, hash, repr, validation)
- [x] Full test suite passes (447 tests)
- [x] mypy strict passes

https://claude.ai/code/session_015qzrA91PKa7Ngu3SfTLBDj