### PR TITLE
refactor: reduce sync/async duplication in Container resolution methods

### DIFF
--- a/inversipy/_wrappers.py
+++ b/inversipy/_wrappers.py
@@ -5,6 +5,7 @@ dependency resolution. They live in their own module so resolution-time
 wrapper creation is decoupled from container orchestration.
 """
 
+from collections.abc import Callable, Coroutine
 from typing import TYPE_CHECKING, Any
 
 from .exceptions import AmbiguousDependencyError
@@ -21,6 +22,44 @@ def _format_dependency(dep_type: type, name: str | None = None) -> str:
     return dep_type.__name__
 
 
+def _build_wrapper(
+    wrapper_type: type,
+    dep_type: type,
+    dep_name: str | None,
+    container: "Container",
+    sync_resolver: Callable[..., Any],
+    async_resolver: Callable[..., Coroutine[Any, Any, Any]] | None,
+) -> Factory | Lazy:  # type: ignore[type-arg]
+    """Construct a Factory or Lazy wrapper from prepared resolvers.
+
+    Shared between the sync-only (_make_wrapper) and async-aware
+    (_make_wrapper_async) entry points. The caller supplies the resolver
+    closures; this helper handles the Factory/Lazy branching, the cached
+    Lazy lookup via the binding's scope strategy, and the eager ambiguity
+    check.
+    """
+    if wrapper_type is Factory:
+        if async_resolver is not None:
+            return Factory(sync_resolver, async_resolver)
+        return Factory(sync_resolver)
+
+    key = make_key(dep_type, dep_name)
+    binding = container._find_binding(key)
+    if binding is not None:
+        if async_resolver is not None:
+            return binding.create_lazy_wrapper_async(container, dep_type, dep_name)
+        return binding.create_lazy_wrapper(container, dep_type, dep_name)
+
+    # Raise eagerly if ambiguous, rather than deferring to Lazy call time
+    bindings = container._bindings.get(key, [])
+    if len(bindings) > 1:
+        raise AmbiguousDependencyError(dep_type, len(bindings), container._name)
+
+    if async_resolver is not None:
+        return Lazy(sync_resolver, async_resolver)
+    return Lazy(sync_resolver)
+
+
 def _make_wrapper(
     wrapper_type: type, dep_type: type, dep_name: str | None, container: "Container"
 ) -> Factory | Lazy:  # type: ignore[type-arg]
@@ -29,20 +68,7 @@ def _make_wrapper(
     def resolver(_t: type = dep_type, _n: str | None = dep_name) -> Any:
         return container.get(_t, name=_n)
 
-    if wrapper_type is Factory:
-        return Factory(resolver)
-
-    key = make_key(dep_type, dep_name)
-    binding = container._find_binding(key)
-    if binding is not None:
-        return binding.create_lazy_wrapper(container, dep_type, dep_name)
-
-    # Raise eagerly if ambiguous, rather than deferring to Lazy call time
-    bindings = container._bindings.get(key, [])
-    if len(bindings) > 1:
-        raise AmbiguousDependencyError(dep_type, len(bindings), container._name)
-
-    return Lazy(resolver)
+    return _build_wrapper(wrapper_type, dep_type, dep_name, container, resolver, None)
 
 
 def _make_wrapper_async(
@@ -56,17 +82,6 @@ def _make_wrapper_async(
     async def async_resolver(_t: type = dep_type, _n: str | None = dep_name) -> Any:
         return await container.get_async(_t, name=_n)
 
-    if wrapper_type is Factory:
-        return Factory(sync_resolver, async_resolver)
-
-    key = make_key(dep_type, dep_name)
-    binding = container._find_binding(key)
-    if binding is not None:
-        return binding.create_lazy_wrapper_async(container, dep_type, dep_name)
-
-    # Raise eagerly if ambiguous, rather than deferring to Lazy call time
-    bindings = container._bindings.get(key, [])
-    if len(bindings) > 1:
-        raise AmbiguousDependencyError(dep_type, len(bindings), container._name)
-
-    return Lazy(sync_resolver, async_resolver)
+    return _build_wrapper(
+        wrapper_type, dep_type, dep_name, container, sync_resolver, async_resolver
+    )

--- a/inversipy/binding.py
+++ b/inversipy/binding.py
@@ -330,27 +330,22 @@ class Binding:
             case _:
                 raise InvalidScopeError(f"Unknown scope: '{scope}'", scope_name=str(scope))
 
-    def create_lazy_wrapper(
-        self, container: "Container", dep_type: type, dep_name: str | None
+    def _build_lazy_wrapper(
+        self,
+        container: "Container",
+        dep_type: type,
+        dep_name: str | None,
+        *,
+        with_async: bool,
     ) -> "Lazy[Any]":
-        """Create a Lazy wrapper cached through this binding's scope strategy."""
+        """Cache and return a Lazy wrapper, optionally with async resolution."""
 
         def wrapper_factory() -> Lazy[Any]:
             def resolver(_t: type = dep_type, _n: str | None = dep_name) -> Any:
                 return container.get(_t, name=_n)
 
-            return Lazy(resolver)
-
-        return self._lazy_strategy.get(wrapper_factory, is_async_factory=False)  # type: ignore[no-any-return]
-
-    def create_lazy_wrapper_async(
-        self, container: "Container", dep_type: type, dep_name: str | None
-    ) -> "Lazy[Any]":
-        """Create a Lazy wrapper with async support, cached via scope strategy."""
-
-        def wrapper_factory() -> Lazy[Any]:
-            def resolver(_t: type = dep_type, _n: str | None = dep_name) -> Any:
-                return container.get(_t, name=_n)
+            if not with_async:
+                return Lazy(resolver)
 
             async def async_resolver(_t: type = dep_type, _n: str | None = dep_name) -> Any:
                 return await container.get_async(_t, name=_n)
@@ -358,6 +353,18 @@ class Binding:
             return Lazy(resolver, async_resolver)
 
         return self._lazy_strategy.get(wrapper_factory, is_async_factory=False)  # type: ignore[no-any-return]
+
+    def create_lazy_wrapper(
+        self, container: "Container", dep_type: type, dep_name: str | None
+    ) -> "Lazy[Any]":
+        """Create a Lazy wrapper cached through this binding's scope strategy."""
+        return self._build_lazy_wrapper(container, dep_type, dep_name, with_async=False)
+
+    def create_lazy_wrapper_async(
+        self, container: "Container", dep_type: type, dep_name: str | None
+    ) -> "Lazy[Any]":
+        """Create a Lazy wrapper with async support, cached via scope strategy."""
+        return self._build_lazy_wrapper(container, dep_type, dep_name, with_async=True)
 
     def create_instance(self, container: "Container") -> Any:
         """Create an instance of the dependency (sync context)."""

--- a/inversipy/container.py
+++ b/inversipy/container.py
@@ -492,6 +492,16 @@ class Container:
         target = f"class '{cls.__name__}'"
         return await self._resolve_deps_async(deps, target), {}
 
+    @staticmethod
+    def _wrap_instantiate_error(e: Exception, binding: "Binding") -> ResolutionError:
+        """Wrap a non-resolution exception with binding context."""
+        if binding.factory is not None:
+            return ResolutionError(f"Failed to call factory for {binding.key}: {e}")
+        assert binding.implementation is not None
+        return ResolutionError(
+            f"Failed to create instance of {binding.implementation.__name__}: {e}"
+        )
+
     def _instantiate_binding(self, binding: "Binding") -> Any:
         """Create an instance from a binding, resolving its dependencies.
 
@@ -524,12 +534,7 @@ class Container:
         except Exception as e:
             if isinstance(e, _RESOLUTION_ERRORS):
                 raise
-            if binding.factory is not None:
-                raise ResolutionError(f"Failed to call factory for {binding.key}: {e}")
-            assert binding.implementation is not None
-            raise ResolutionError(
-                f"Failed to create instance of {binding.implementation.__name__}: {e}"
-            )
+            raise self._wrap_instantiate_error(e, binding)
 
     async def _instantiate_binding_async(self, binding: "Binding") -> Any:
         """Create an instance from a binding asynchronously, resolving deps."""
@@ -558,12 +563,7 @@ class Container:
         except Exception as e:
             if isinstance(e, _RESOLUTION_ERRORS):
                 raise
-            if binding.factory is not None:
-                raise ResolutionError(f"Failed to call factory for {binding.key}: {e}")
-            assert binding.implementation is not None
-            raise ResolutionError(
-                f"Failed to create instance of {binding.implementation.__name__}: {e}"
-            )
+            raise self._wrap_instantiate_error(e, binding)
 
     def create_child(self, name: str | None = None) -> "Container":
         """Create a child container."""

--- a/inversipy/container.py
+++ b/inversipy/container.py
@@ -33,6 +33,13 @@ from .types import (
     make_key,
 )
 
+_RESOLUTION_ERRORS = (
+    ResolutionError,
+    DependencyNotFoundError,
+    CircularDependencyError,
+    AmbiguousDependencyError,
+)
+
 
 class Container:
     """Dependency injection container.
@@ -447,13 +454,7 @@ class Container:
             resolved_kwargs = self._resolve_deps(deps, target, provided=provided_kwargs)
             return func(**resolved_kwargs)
         except Exception as e:
-            resolution_errors = (
-                ResolutionError,
-                DependencyNotFoundError,
-                CircularDependencyError,
-                AmbiguousDependencyError,
-            )
-            if isinstance(e, resolution_errors):
+            if isinstance(e, _RESOLUTION_ERRORS):
                 raise
             raise ResolutionError(f"Failed to run function '{func.__name__}': {e}")
 
@@ -465,13 +466,7 @@ class Container:
             resolved_kwargs = await self._resolve_deps_async(deps, target, provided=provided_kwargs)
             return func(**resolved_kwargs)
         except Exception as e:
-            resolution_errors = (
-                ResolutionError,
-                DependencyNotFoundError,
-                CircularDependencyError,
-                AmbiguousDependencyError,
-            )
-            if isinstance(e, resolution_errors):
+            if isinstance(e, _RESOLUTION_ERRORS):
                 raise
             raise ResolutionError(f"Failed to run function '{func.__name__}': {e}")
 
@@ -528,15 +523,7 @@ class Container:
             kwargs = self._resolve_deps(deps, target)
             return binding._invoke(**kwargs)
         except Exception as e:
-            if isinstance(
-                e,
-                (
-                    ResolutionError,
-                    DependencyNotFoundError,
-                    CircularDependencyError,
-                    AmbiguousDependencyError,
-                ),
-            ):
+            if isinstance(e, _RESOLUTION_ERRORS):
                 raise
             if binding.factory is not None:
                 raise ResolutionError(f"Failed to call factory for {binding.key}: {e}")
@@ -570,15 +557,7 @@ class Container:
                 return await result
             return result
         except Exception as e:
-            if isinstance(
-                e,
-                (
-                    ResolutionError,
-                    DependencyNotFoundError,
-                    CircularDependencyError,
-                    AmbiguousDependencyError,
-                ),
-            ):
+            if isinstance(e, _RESOLUTION_ERRORS):
                 raise
             if binding.factory is not None:
                 raise ResolutionError(f"Failed to call factory for {binding.key}: {e}")

--- a/inversipy/container.py
+++ b/inversipy/container.py
@@ -502,6 +502,13 @@ class Container:
             f"Failed to create instance of {binding.implementation.__name__}: {e}"
         )
 
+    @staticmethod
+    def _instantiate_target_name(binding: "Binding") -> str:
+        """Format the target description used in resolve-error messages."""
+        if binding.implementation is not None:
+            return f"class '{binding.implementation.__name__}'"
+        return f"factory for {binding.key}"
+
     def _instantiate_binding(self, binding: "Binding") -> Any:
         """Create an instance from a binding, resolving its dependencies.
 
@@ -524,11 +531,7 @@ class Container:
             assert binding._provider is not None
             assert binding._invoke is not None
             deps = analyze_parameters(binding._provider, skip_self=True)
-            target = (
-                f"class '{binding.implementation.__name__}'"
-                if binding.implementation is not None
-                else f"factory for {binding.key}"
-            )
+            target = self._instantiate_target_name(binding)
             kwargs = self._resolve_deps(deps, target)
             return binding._invoke(**kwargs)
         except Exception as e:
@@ -550,11 +553,7 @@ class Container:
             assert binding._provider is not None
             assert binding._invoke is not None
             deps = analyze_parameters(binding._provider, skip_self=True)
-            target = (
-                f"class '{binding.implementation.__name__}'"
-                if binding.implementation is not None
-                else f"factory for {binding.key}"
-            )
+            target = self._instantiate_target_name(binding)
             kwargs = await self._resolve_deps_async(deps, target)
             result = binding._invoke(**kwargs)
             if asyncio.iscoroutine(result):

--- a/inversipy/container.py
+++ b/inversipy/container.py
@@ -168,10 +168,17 @@ class Container:
         self._modules.append(module)
         return self
 
-    def get[T](self, interface: type[T], name: str | None = None) -> T:
-        """Resolve a dependency from the container."""
-        key = make_key(interface, name)
+    def _lookup_local_binding(
+        self, key: DependencyKey, interface: type[Any]
+    ) -> Optional["Binding"]:
+        """Run cycle and ambiguity checks, return the local binding if any.
 
+        Shared between sync and async resolution paths. Raises
+        CircularDependencyError if ``key`` is already on the resolution stack
+        and AmbiguousDependencyError if more than one binding is registered
+        locally. Returns the single local binding, or None to signal that the
+        caller should fall back to modules and parent.
+        """
         if key in self._resolution_stack:
             cycle_types = [get_type_from_key(k) for k in self._resolution_stack] + [
                 get_type_from_key(key)
@@ -179,11 +186,15 @@ class Container:
             raise CircularDependencyError(cycle_types)
 
         bindings = self._bindings.get(key, [])
-
         if len(bindings) > 1:
             raise AmbiguousDependencyError(interface, len(bindings), self._name)
 
-        binding = bindings[0] if len(bindings) == 1 else None
+        return bindings[0] if len(bindings) == 1 else None
+
+    def get[T](self, interface: type[T], name: str | None = None) -> T:
+        """Resolve a dependency from the container."""
+        key = make_key(interface, name)
+        binding = self._lookup_local_binding(key, interface)
 
         if binding is None:
             for module in self._modules:
@@ -245,19 +256,7 @@ class Container:
     async def get_async[T](self, interface: type[T], name: str | None = None) -> T:
         """Resolve a dependency from the container asynchronously."""
         key = make_key(interface, name)
-
-        if key in self._resolution_stack:
-            cycle_types = [get_type_from_key(k) for k in self._resolution_stack] + [
-                get_type_from_key(key)
-            ]
-            raise CircularDependencyError(cycle_types)
-
-        bindings = self._bindings.get(key, [])
-
-        if len(bindings) > 1:
-            raise AmbiguousDependencyError(interface, len(bindings), self._name)
-
-        binding = bindings[0] if len(bindings) == 1 else None
+        binding = self._lookup_local_binding(key, interface)
 
         if binding is None:
             for module in self._modules:


### PR DESCRIPTION
Closes #60.

Extracts the genuinely shared pieces of the sync/async resolution paths into small helpers so the two branches stop drifting apart. Python's sync/async divide still forces two entry points (`get`/`get_async`, `_instantiate_binding`/`_instantiate_binding_async`, etc.), but everything around the `await` is now shared.

## Changes (one commit per helper)

1. **`refactor(container): extract _RESOLUTION_ERRORS module constant`** — replaces four identical inline tuples in `_instantiate_binding`, `_instantiate_binding_async`, `run`, `run_async`.
2. **`refactor(container): extract _lookup_local_binding helper`** — shares the cycle-check + ambiguity-check + local lookup that opened both `get()` and `get_async()`.
3. **`refactor(container): extract _wrap_instantiate_error helper`** — pulls the identical "factory for X" vs "create instance of Y" `ResolutionError` construction out of both `_instantiate_binding*` methods.
4. **`refactor(container): extract _instantiate_target_name helper`** — single source for the error-message target format.
5. **`refactor(wrappers): extract _build_wrapper to share Factory/Lazy logic`** — the Factory/Lazy branching, cached `Binding.create_lazy_wrapper*` lookup, and eager ambiguity check now live in one helper; `_make_wrapper` / `_make_wrapper_async` are thin resolver-building wrappers.
6. **`refactor(binding): consolidate Lazy wrapper creation via _build_lazy_wrapper`** — `Binding.create_lazy_wrapper` and `create_lazy_wrapper_async` differed only in one optional resolver; they now both call a `_build_lazy_wrapper(..., with_async=)` helper.

## What's intentionally left alone

`_resolve_deps` / `_resolve_deps_async`, `get_all` / `get_all_async`, and the tiny `_resolve_injectable_deps*` delegators all contain per-iteration `await` that Python can't express in sync code. Trying to share the loop body would require callback indirection that hurts readability more than the duplication does. The issue acknowledges this limit.

## Test plan

- [x] `uv run pytest` — all 447 tests pass on every commit.
- [x] No public API changes; only private helpers added / method bodies slimmed.
- [x] Each commit builds and tests independently (enforces the "one commit per logical change" rule from `CLAUDE.md`).

https://claude.ai/code/session_013Xh4LCpnwNxCFsarvdpD4C